### PR TITLE
feat: split targets into machines and routes, add TCP routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.iml
 *.idea/
 .aider*
+
+# build output
+go-wol-proxy
+*.migrated.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ WORKDIR /app
 # Copy the binary from the builder stage
 COPY --from=builder /app/go-wol-proxy /app/
 
-# Expose the default port
+# Expose the default port. TCP routes listen on their own ports; with
+# network_mode: host they are reachable directly, otherwise publish each one.
 EXPOSE 8080
 
 # Run the application

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ the SSH version banner rather than on connect. If your box is slow to wake, rais
 If you configure only TCP routes, `port` is still bound and answers 404 to
 everything. That is expected.
 
+> **A TCP route is a new way in to that service.** `listen_port = 2222` forwarding to
+> `nas.local:22` makes that sshd reachable by anything that can reach the proxy, on
+> every interface the proxy listens on. Authentication is unaffected — sshd still
+> authenticates every connection — but a service that was previously only reachable
+> on your LAN now depends on where the proxy is exposed. Bind the proxy somewhere you
+> trust, and think before putting a TCP route in front of something that was relying
+> on being hard to reach.
+
 ### Liveness vs readiness
 
 There are two `health_check` fields and they answer different questions:
@@ -185,6 +193,13 @@ Run the container with Docker Compose:
 ```bash
 docker-compose up -d
 ```
+
+## Signals
+
+`SIGINT`/`SIGTERM` shuts the proxy down cleanly: it stops accepting, gives in-flight
+HTTP requests up to 15 seconds to finish, closes the TCP listeners and exits 0.
+In-flight TCP connections are dropped rather than drained — a forwarded ssh session
+ends when the proxy stops.
 
 ## Graceful Shutdown Options
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ everything. That is expected.
 > trust, and think before putting a TCP route in front of something that was relying
 > on being hard to reach.
 
+> [!TIP]
+> **Let sshd close idle sessions so the proxy can suspend the box.** A forwarded ssh
+> connection holds the machine awake for as long as the client stays connected, so a
+> terminal left open all day keeps the box awake all day. Have sshd close idle
+> sessions on its side and the proxy's `inactivity_threshold` will do the rest — for
+> example, in `sshd_config`:
+>
+> ```
+> ChannelTimeout *=10m
+> UnusedConnectionTimeout 1m
+> ```
+>
+> Once sshd closes the connection, the proxy releases its hold and the inactivity
+> countdown starts.
+
 ### Liveness vs readiness
 
 There are two `health_check` fields and they answer different questions:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,25 @@ There are two `health_check` fields and they answer different questions:
 A route's readiness is only polled while its machine is live, so a machine that is
 asleep most of the time generates no per-route traffic.
 
+### Config validation
+
+The config is checked at startup and the proxy refuses to run on a bad one, rather
+than starting and misbehaving later:
+
+- **`machines[].health_check` is required.** Without it every check fails, the machine
+  is permanently unhealthy, and every request wakes it — spraying WOL packets for the
+  whole `timeout` before returning 503.
+- **`destination` is validated per route kind**: `host:port` for a TCP route, an
+  `http://` or `https://` URL for an HTTP route. A schemeless HTTP destination such as
+  `nas.local:2342` parses as a URL scheme named `nas.local` and would otherwise 502
+  every request with nothing in the logs to explain it.
+- **Unknown keys are an error.** A misspelled key would otherwise decode silently to a
+  zero value, which is the usual way a config ends up missing a health check with no
+  hint as to why. The error lists the offending keys.
+
+A legacy `[[targets]]` config is held to the same rules, reported against the key
+names that format uses.
+
 ### Inactivity and shutdown
 
 Each machine has one inactivity clock, fed by every route that points at it. Traffic

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A Wake-on-LAN proxy service written in Go that automatically wakes up servers wh
 
 ## Features
 
-- Proxies HTTP requests to configured target servers
+- Proxies HTTP requests to configured target servers, routed by Host header
+- :star: new :star: Forwards raw TCP too — ssh and anything else that isn't HTTP
 - Automatically sends Wake-on-LAN packets to wake up offline servers
 - Monitors server health with configurable intervals
 - Caches health status to minimize latency for frequent requests
@@ -13,54 +14,120 @@ A Wake-on-LAN proxy service written in Go that automatically wakes up servers wh
 
 ## Configuration
 
-The service is configured using a TOML file. Here's an example configuration:
+The service is configured using a TOML file. A **machine** is a host that gets woken
+and shut down as one unit; a **route** is one way in to it. Many routes can point at
+one machine, so a box you keep asleep is reachable however you like without
+configuring it several times over.
 
 ```toml
-port = ":8080"                  # Port to listen on
-timeout = "1m"                  # How long to wait for server to wake up
-response_header_timeout = "1m"  # How long to wait for a response header, e.g. during or after slow or long-running requests/uploads
-poll_interval = "5s"            # How often to check health during wake-up
+port = ":8080"                  # Port to listen on for HTTP routes
+timeout = "1m"                  # How long to wait for a machine to wake / a route to become ready
+response_header_timeout = "1m"  # How long to wait for a response header, e.g. during slow or long-running requests/uploads
+poll_interval = "5s"            # How often to check health while waiting
 health_check_interval = "30s"   # Background health check frequency
-health_cache_duration = "10s"   # How long to trust cached health status
+health_cache_duration = "10s"   # How long to trust a cached health result
 
-# Optional SSL configuration Do not add these values unless you plan to use TLS/HTTPS
-ssl_certificate = "/path/to/cert.pem"   # Path to your SSL certificate
-ssl_certificate_key = "/path/to/key.pem" # Path to your SSL private key
+# Optional SSL configuration. Do not add these values unless you plan to use TLS/HTTPS
+#ssl_certificate = "/path/to/cert.pem"
+#ssl_certificate_key = "/path/to/key.pem"
 
-
-[[targets]]
-name = "service"
-hostname = "service.host.com"                 # The "external" hostname - what this server receives as a Host header
-destination = "http://service.local"          # The actual url to the server
-health_endpoint = "http://service.local/ping" # url to check health
-mac_address = "7c:8b:ad:da:be:51"             # MAC address for WOL
-broadcast_ip = "10.0.0.255"                   # Broadcast IP for WOL
-wol_port = 9                                  # Port for WOL packets
-# Optional: Graceful shutdown configuration (SSH or HTTP)
-inactivity_threshold = "1h"                   # Shut down after 1 hour of inactivity
-
-# Option A: SSH-based shutdown (use either Option A or Option B, not both)
-ssh_host = "service.local:22"                 # SSH host:port for shutdown
-ssh_user = "wol-proxy"                        # SSH username for shutdown
-ssh_key_path = "/app/private_key"             # Path to SSH private key
-shutdown_command = "sudo systemctl suspend"   # Command to execute for shutdown
-# ^ take care - wake from suspend / shutdown can be flaky on some systems.
-# if your machine doesnt wake from your chosen "sleep" mode, try another.
-
-# Option B: HTTP-based shutdown (use either Option A or Option B, not both)
-#shutdown_http_url = "http://service.local/api/shutdown" # URL to trigger shutdown (final response validated)
-#shutdown_http_method = "POST"                              # Optional; defaults to POST
-#shutdown_http_ok_status = 0                                 # Optional; 0=accept any 2xx (default). Set e.g. 202 to require specific code
-
-[[targets]]
-name = "service2"
-hostname = "service2.host.com"
-destination = "http://service2.local"
-health_endpoint = "http://service2.local/ping"
-mac_address = "c9:69:45:d2:1e:12"
+[[machines]]
+name = "nas"
+mac_address = "7c:8b:ad:da:be:51"
 broadcast_ip = "10.0.0.255"
 wol_port = 9
+health_check = "tcp://nas.local:22"   # liveness: is the box up?
+inactivity_threshold = "1h"           # optional; omit to never shut it down
+
+ssh_host = "nas.local:22"
+ssh_user = "wol-proxy"
+ssh_key_path = "/app/private_key"
+shutdown_command = "sudo systemctl suspend"
+
+# HTTP routes are matched on the Host header, so they share `port`.
+[[routes]]
+machine = "nas"
+hostname = "files.home.com"
+destination = "http://nas.local"
+
+[[routes]]
+machine = "nas"
+hostname = "photos.home.com"
+destination = "http://nas.local:2342"
+health_check = "http://nas.local:2342/ping"   # readiness: can this route serve?
+
+# A TCP route has no Host header to match on, so it gets its own port. This is how
+# you put ssh — or anything else that isn't HTTP — behind the proxy.
+[[routes]]
+machine = "nas"
+listen_port = 2222
+destination = "nas.local:22"
 ```
+
+See [config.toml](config.toml) for a fully commented example.
+
+### Routes: hostname or listen port
+
+A route is reached one way or the other, never both:
+
+| | matched on | `destination` | shares `port` |
+|---|---|---|---|
+| HTTP route | `hostname` (Host header) | a URL | yes |
+| TCP route | `listen_port` (its own socket) | `host:port` | no |
+
+TCP carries no Host header, so a TCP route cannot be multiplexed onto the shared
+port — it needs one of its own. Setting both `hostname` and `listen_port` on a route,
+or neither, is a config error.
+
+Connections on a TCP route are spliced byte for byte, so ssh host keys pass through
+untouched: no man-in-the-middle, and no `known_hosts` churn. The proxy accepts your
+connection immediately and wakes the machine while you wait, so your client waits on
+the SSH version banner rather than on connect. If your box is slow to wake, raise
+`timeout` here and `ConnectTimeout` in your `ssh_config`.
+
+If you configure only TCP routes, `port` is still bound and answers 404 to
+everything. That is expected.
+
+### Liveness vs readiness
+
+There are two `health_check` fields and they answer different questions:
+
+- **`machines[].health_check`** — *liveness*: is the box up? This drives Wake-on-LAN
+  and the wake wait. It must not depend on any single service, or a crashed service
+  would have the proxy firing magic packets at a machine that is already awake. A TCP
+  dial to something always-on, like `tcp://nas.local:22`, is usually right.
+- **`routes[].health_check`** — *readiness*: can this route serve? It gates forwarding
+  for that route alone. It defaults to dialling the route's `destination`, inferring
+  `:80`/`:443` from a URL scheme when the port is implicit. Point it at a real health
+  endpoint when a service takes noticeably longer to come up than the box does —
+  otherwise a wake that succeeds can still hand you a 502.
+
+A route's readiness is only polled while its machine is live, so a machine that is
+asleep most of the time generates no per-route traffic.
+
+### Inactivity and shutdown
+
+Each machine has one inactivity clock, fed by every route that points at it. Traffic
+on any route keeps the whole machine alive.
+
+A machine is shut down when it has had no traffic for `inactivity_threshold` **and**
+has no forwarded connection open. The second condition matters: an ssh session is
+idle by nature, and a large upload can outlast the threshold — neither should be
+suspended out from under you.
+
+Omitting `inactivity_threshold`, or setting it to `"0s"`, means the machine is never
+shut down.
+
+### Migrating from `[[targets]]`
+
+The old `[[targets]]` format still loads. On startup the proxy translates it, logs
+what it did, and writes the converted config next to the original as
+`<name>.migrated.toml` — review it and `mv` it into place. Your original file is
+never modified: it is often bind-mounted read-only or checked into a config repo, and
+rewriting it would drop every comment. If the sidecar cannot be written, the
+converted config is logged instead.
+
+A config may use one format or the other, not both.
 
 ## Docker Usage
 
@@ -76,6 +143,10 @@ docker pull ghcr.io/darksworm/go-wol-proxy:latest
 # Note: network mode "host" is required for Wake-on-LAN packets to be sent correctly
 docker run --network host -v /path/to/config.toml:/app/config.toml ghcr.io/darksworm/go-wol-proxy:latest
 ```
+
+With `network_mode: host` every `listen_port` you configure is reachable on the host
+directly. Prefer high ports — `listen_port = 2222` rather than `22` — so a TCP route
+does not collide with the host's own sshd.
 
 ### Build the Docker Image Locally
 
@@ -118,11 +189,11 @@ docker-compose up -d
 ## Graceful Shutdown Options
 
 - Trigger a shutdown after a period of inactivity using SSH or HTTP.
-- Exactly one mechanism must be configured per target: SSH or HTTP, not both.
+- Exactly one mechanism must be configured per machine: SSH or HTTP, not both.
 
 ### SSH-based Shutdown
 - Use `ssh_host`, `ssh_user`, `ssh_key_path`, and `shutdown_command`.
-- The proxy executes the command over SSH when the target is inactive.
+- The proxy executes the command over SSH when the machine is inactive.
 
 ### HTTP-based Shutdown
 - Use `shutdown_http_url` to enable HTTP shutdown.
@@ -132,7 +203,7 @@ docker-compose up -d
 - The shutdown HTTP request uses a 10s timeout.
 
 ### Validation Rules
-- You cannot set both `shutdown_http_url` and `shutdown_command` for the same target.
+- You cannot set both `shutdown_http_url` and `shutdown_command` for the same machine.
 - If `shutdown_http_method` and/or `shutdown_http_ok_status` are set, `shutdown_http_url` must also be set.
 
 ### Similar projects:

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ everything. That is expected.
 > connection holds the machine awake for as long as the client stays connected, so a
 > terminal left open all day keeps the box awake all day. Have sshd close idle
 > sessions on its side and the proxy's `inactivity_threshold` will do the rest — for
-> example, in `sshd_config`:
+> example, in `sshd_config` (requires OpenSSH 9.3 or later):
 >
-> ```
+> ```text
 > ChannelTimeout *=10m
 > UnusedConnectionTimeout 1m
 > ```

--- a/config.toml
+++ b/config.toml
@@ -1,29 +1,74 @@
-port = ":8080"                  # Port to listen on
-timeout = "1m"                  # How long to wait for server to wake up
-response_header_timeout = "1m"  # How long to wait for a response header, e.g. during or after slow or long-running requests/uploads
-poll_interval = "5s"            # How often to check health during wake-up
+port = ":8080"                  # Port to listen on for HTTP routes
+timeout = "1m"                  # How long to wait for a machine to wake / a route to become ready
+response_header_timeout = "1m"  # How long to wait for a response header, e.g. during slow or long-running requests/uploads
+poll_interval = "5s"            # How often to check health while waiting
 health_check_interval = "30s"   # Background health check frequency
-health_cache_duration = "10s"   # How long to trust cached health status
+health_cache_duration = "10s"   # How long to trust a cached health result
 
-[[targets]]
-name = "service"
-hostname = "service.host.com"                 # The "external" hostname - what this server receives as a Host header
-destination = "http://service.local"          # The actual url to the server
-health_endpoint = "http://service.local/ping" # url to check health
-mac_address = "7c:8b:ad:da:be:51"             # MAC address for WOL
-broadcast_ip = "10.0.0.255"                   # Broadcast IP for WOL
-wol_port = 9                                  # Port for WOL packets
-inactivity_threshold = "1h"                   # Shut down after 1 hour of inactivity
-ssh_host = "service.local:22"                 # SSH host:port for shutdown
-ssh_user = "wol-proxy"                        # SSH username for shutdown
-ssh_key_path = "/home/ilmars/.ssh/id_rsa"     # Path to SSH private key
-shutdown_command = "sudo shutdown -h now"     # Command to execute for shutdown
+# Optional SSL configuration. Do not add these values unless you plan to use TLS/HTTPS
+#ssl_certificate = "/path/to/cert.pem"
+#ssl_certificate_key = "/path/to/key.pem"
 
-[[targets]]
-name = "service2"
-hostname = "service2.host.com"
-destination = "http://service2.local"
-health_endpoint = "http://service2.local/ping"
+# A machine is a host that gets woken and shut down as one unit, however many
+# routes point at it.
+[[machines]]
+name = "nas"
+mac_address = "7c:8b:ad:da:be:51"
+broadcast_ip = "10.0.0.255"
+wol_port = 9
+
+# Liveness: is the box up? Must not depend on any one service on it, or a crashed
+# service would have the proxy sending magic packets at a machine that is awake.
+health_check = "tcp://nas.local:22"
+
+# Optional. The machine is suspended after this long with no traffic on any of its
+# routes and no forwarded connection open. Omit it to never shut the machine down.
+inactivity_threshold = "1h"
+
+# Shutdown over SSH (use this or the HTTP form below, not both)
+ssh_host = "nas.local:22"
+ssh_user = "wol-proxy"
+ssh_key_path = "/app/private_key"
+shutdown_command = "sudo systemctl suspend"
+# ^ take care - wake from suspend / shutdown can be flaky on some systems.
+# if your machine doesnt wake from your chosen "sleep" mode, try another.
+
+# Shutdown over HTTP instead
+#shutdown_http_url = "http://nas.local/api/shutdown"
+#shutdown_http_method = "POST"     # Optional; defaults to POST
+#shutdown_http_ok_status = 202     # Optional; omit to accept any 2xx
+
+# An HTTP route is matched on the Host header, so many of them can share port 8080.
+[[routes]]
+machine = "nas"
+hostname = "files.home.com"
+destination = "http://nas.local"
+
+[[routes]]
+machine = "nas"
+hostname = "photos.home.com"
+destination = "http://nas.local:2342"
+# Readiness: can this route serve? Defaults to dialling `destination`, which only
+# tells you something is listening. Point it at a real health endpoint when the
+# service takes a while to come up after the box does.
+health_check = "http://nas.local:2342/ping"
+
+# A TCP route has no Host header to match on, so it gets its own listening port.
+# This is how you put ssh, or anything else that isn't HTTP, behind the proxy.
+[[routes]]
+machine = "nas"
+listen_port = 2222
+destination = "nas.local:22"
+
+# A second machine, HTTP only.
+[[machines]]
+name = "media"
 mac_address = "c9:69:45:d2:1e:12"
 broadcast_ip = "10.0.0.255"
 wol_port = 9
+health_check = "http://media.local/ping"
+
+[[routes]]
+machine = "media"
+hostname = "media.home.com"
+destination = "http://media.local"

--- a/main.go
+++ b/main.go
@@ -219,11 +219,17 @@ func (m *Machine) holdConnection() {
 	m.mu.Unlock()
 }
 
-func (m *Machine) releaseConnection() {
+// releaseConnection decrements the in-flight counter and stamps LastActivity to
+// now. Stamping on release is what makes the inactivity countdown start at
+// disconnect: a long-running session — an ssh login left open for hours — would
+// otherwise carry a stale LastActivity from when it began, and the very next
+// inactivity tick after logout would exceed the threshold and shut the box down.
+func (m *Machine) releaseConnection(now time.Time) {
 	m.mu.Lock()
 	if m.openConns > 0 {
 		m.openConns--
 	}
+	m.LastActivity = now
 	m.mu.Unlock()
 }
 
@@ -1104,7 +1110,7 @@ func (p *ProxyService) forwardTCPConn(ctx context.Context, client net.Conn, rout
 	machine.mu.Unlock()
 
 	machine.holdConnection()
-	defer machine.releaseConnection()
+	defer func() { machine.releaseConnection(p.clock.Now()) }()
 
 	// Both directions must finish before the deferred closes run. A client that
 	// half-closes its write side — ssh and scp both do, once the request is sent —
@@ -1143,7 +1149,7 @@ func (p *ProxyService) proxyRequest(w http.ResponseWriter, r *http.Request, rout
 	// A slow upload or download can outlast the inactivity threshold; hold the
 	// machine for as long as the request is in flight.
 	machineState.holdConnection()
-	defer machineState.releaseConnection()
+	defer func() { machineState.releaseConnection(p.clock.Now()) }()
 
 	targetURL, err := url.Parse(route.Destination)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 // Interfaces for dependency injection
 type HealthChecker interface {
 	Check(ctx context.Context, endpoint string, source string) bool
-	StartBackgroundChecks(ctx context.Context, targets map[string]*TargetState, interval time.Duration)
+	StartBackgroundChecks(ctx context.Context, machines map[string]*MachineState, interval time.Duration)
 	WaitForInitialChecks(ctx context.Context) error
 	CloseIdleConnections()
 }
@@ -94,6 +94,32 @@ type Target struct {
 	InactivityThreshold  string `toml:"inactivity_threshold"`
 }
 
+// Machine is a host that is woken, health-checked and shut down as one unit,
+// however many routes point at it.
+type Machine struct {
+	Name                 string
+	MacAddress           string
+	BroadcastIP          string
+	WolPort              int
+	HealthCheck          string
+	SSHHost              string
+	SSHUser              string
+	SSHKeyPath           string
+	ShutdownCommand      string
+	ShutdownHTTPUrl      string
+	ShutdownHTTPMethod   string
+	ShutdownHTTPOKStatus int
+	InactivityThreshold  time.Duration
+}
+
+// Route is one way in to a machine.
+type Route struct {
+	Name        string
+	Machine     *MachineState
+	Hostname    string
+	Destination string
+}
+
 type ProxyConfig struct {
 	Port                  string
 	Timeout               time.Duration
@@ -101,15 +127,15 @@ type ProxyConfig struct {
 	PollInterval          time.Duration
 	HealthCheckInterval   time.Duration
 	HealthCacheDuration   time.Duration
-	Targets               map[string]*TargetState
-	HostnameMap           map[string]string        // hostname -> target name
-	InactivityThresholds  map[string]time.Duration // target name -> inactivity threshold
+	Machines              map[string]*MachineState
+	Routes                []*Route
+	RoutesByHostname      map[string]*Route
 	SSLCertificate        string
 	SSLCertificateKey     string
 }
 
-type TargetState struct {
-	Target       *Target
+type MachineState struct {
+	Machine      *Machine
 	IsHealthy    bool
 	LastCheck    time.Time
 	IsWaking     bool
@@ -170,10 +196,10 @@ func (h *HTTPHealthChecker) Check(ctx context.Context, endpoint string, source s
 	return true
 }
 
-func (h *HTTPHealthChecker) StartBackgroundChecks(ctx context.Context, targets map[string]*TargetState, interval time.Duration) {
-	for name, target := range targets {
+func (h *HTTPHealthChecker) StartBackgroundChecks(ctx context.Context, machines map[string]*MachineState, interval time.Duration) {
+	for name, machine := range machines {
 		h.initialWaitGroup.Add(1)
-		go h.backgroundCheck(ctx, name, target, interval)
+		go h.backgroundCheck(ctx, name, machine, interval)
 	}
 }
 
@@ -192,9 +218,9 @@ func (h *HTTPHealthChecker) WaitForInitialChecks(ctx context.Context) error {
 	}
 }
 
-func (h *HTTPHealthChecker) backgroundCheck(ctx context.Context, name string, target *TargetState, interval time.Duration) {
+func (h *HTTPHealthChecker) backgroundCheck(ctx context.Context, name string, machine *MachineState, interval time.Duration) {
 	// Perform initial check
-	h.performCheck(name, target)
+	h.performCheck(name, machine)
 	h.markInitialCheckDone(name)
 	h.initialWaitGroup.Done()
 
@@ -206,44 +232,44 @@ func (h *HTTPHealthChecker) backgroundCheck(ctx context.Context, name string, ta
 		case <-ctx.Done():
 			return
 		case <-ticker.C():
-			h.performCheck(name, target)
+			h.performCheck(name, machine)
 		}
 	}
 }
 
-func (h *HTTPHealthChecker) performCheck(name string, target *TargetState) {
-	target.mu.RLock()
-	isWaking := target.IsWaking
-	target.mu.RUnlock()
+func (h *HTTPHealthChecker) performCheck(name string, machine *MachineState) {
+	machine.mu.RLock()
+	isWaking := machine.IsWaking
+	machine.mu.RUnlock()
 	if isWaking {
 		h.logger.Info("Background health check for %s (%s) running while wake is in progress",
-			name, target.Target.Hostname)
+			name, machine.Machine.HealthCheck)
 	}
 
 	checkStarted := h.clock.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	healthy := h.Check(ctx, target.Target.HealthEndpoint, "background")
+	healthy := h.Check(ctx, machine.Machine.HealthCheck, "background")
 
-	target.mu.Lock()
-	previousHealth := target.IsHealthy
-	target.IsHealthy = healthy
-	target.LastCheck = h.clock.Now()
-	target.mu.Unlock()
+	machine.mu.Lock()
+	previousHealth := machine.IsHealthy
+	machine.IsHealthy = healthy
+	machine.LastCheck = h.clock.Now()
+	machine.mu.Unlock()
 
 	if healthy != previousHealth {
 		status := "DOWN"
 		if healthy {
 			status = "UP"
 		}
-		h.logger.Info("Health check for %s (%s): %s", name, target.Target.Hostname, status)
+		h.logger.Info("Health check for %s (%s): %s", name, machine.Machine.HealthCheck, status)
 	}
 
 	if !healthy && previousHealth {
 		h.logger.Info(
 			"Background health check for %s (%s): downgrading healthy to unhealthy (check took %v)",
-			name, target.Target.Hostname, h.clock.Now().Sub(checkStarted).Round(time.Millisecond),
+			name, machine.Machine.HealthCheck, h.clock.Now().Sub(checkStarted).Round(time.Millisecond),
 		)
 	}
 
@@ -399,29 +425,29 @@ func NewProxyService(
 	}
 }
 
-func (p *ProxyService) shutdownTarget(targetName string) error {
-	targetState, exists := p.config.Targets[targetName]
+func (p *ProxyService) shutdownMachine(machineName string) error {
+	machineState, exists := p.config.Machines[machineName]
 	if !exists {
-		return fmt.Errorf("unknown target: %s", targetName)
+		return fmt.Errorf("unknown machine: %s", machineName)
 	}
 
-	target := targetState.Target
-    if (target.SSHHost == "" || target.SSHUser == "" || target.SSHKeyPath == "" || target.ShutdownCommand == "") && target.ShutdownHTTPUrl == "" {
-        return fmt.Errorf("target %s is missing SSH configuration or shutdown command or shutdown HTTP URL", targetName)
-    }
+	machine := machineState.Machine
+	if (machine.SSHHost == "" || machine.SSHUser == "" || machine.SSHKeyPath == "" || machine.ShutdownCommand == "") && machine.ShutdownHTTPUrl == "" {
+		return fmt.Errorf("machine %s is missing SSH configuration or shutdown command or shutdown HTTP URL", machineName)
+	}
 
-	p.logger.Info("Shutting down target %s (%s) due to inactivity", targetName, target.Hostname)
-	if target.ShutdownHTTPUrl != "" {
+	p.logger.Info("Shutting down machine %s due to inactivity", machineName)
+	if machine.ShutdownHTTPUrl != "" {
 		// Attempt to shut down via HTTP request
-		method := target.ShutdownHTTPMethod
+		method := machine.ShutdownHTTPMethod
 		if method == "" {
 			method = "POST" // Default to POST if not specified
 		}
 
-        req, err := http.NewRequest(method, target.ShutdownHTTPUrl, nil)
-        if err != nil {
-            return fmt.Errorf("failed to create shutdown request: %w", err)
-        }
+		req, err := http.NewRequest(method, machine.ShutdownHTTPUrl, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create shutdown request: %w", err)
+		}
 
 		// Send the request
 		client := &http.Client{
@@ -433,35 +459,35 @@ func (p *ProxyService) shutdownTarget(targetName string) error {
 		}
 		defer resp.Body.Close()
 
-        // Accept any 2xx status by default; allow explicit status override
-        if target.ShutdownHTTPOKStatus != 0 {
-            if resp.StatusCode != target.ShutdownHTTPOKStatus {
-                return fmt.Errorf("shutdown request failed with status: %s", resp.Status)
-            }
-        } else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-            return fmt.Errorf("shutdown request failed with status: %s", resp.Status)
-        }
+		// Accept any 2xx status by default; allow explicit status override
+		if machine.ShutdownHTTPOKStatus != 0 {
+			if resp.StatusCode != machine.ShutdownHTTPOKStatus {
+				return fmt.Errorf("shutdown request failed with status: %s", resp.Status)
+			}
+		} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("shutdown request failed with status: %s", resp.Status)
+		}
 
 	} else {
-		err := p.sshExecutor.ExecuteCommand(target.SSHHost, target.SSHUser, target.SSHKeyPath, target.ShutdownCommand)
+		err := p.sshExecutor.ExecuteCommand(machine.SSHHost, machine.SSHUser, machine.SSHKeyPath, machine.ShutdownCommand)
 		if err != nil {
-			p.logger.Error("Failed to shut down target %s: %v", targetName, err)
+			p.logger.Error("Failed to shut down machine %s: %v", machineName, err)
 			return err
 		}
 	}
 
-	// Mark the target as unhealthy after shutdown
-	targetState.mu.Lock()
-	targetState.IsHealthy = false
-	targetState.mu.Unlock()
+	// Mark the machine as unhealthy after shutdown
+	machineState.mu.Lock()
+	machineState.IsHealthy = false
+	machineState.mu.Unlock()
 	p.healthChecker.CloseIdleConnections()
 
-	p.logger.Info("Target %s (%s) has been shut down", targetName, target.Hostname)
+	p.logger.Info("Machine %s has been shut down", machineName)
 	return nil
 }
 
 func (p *ProxyService) startInactivityMonitor(ctx context.Context) {
-	// Check every 10 seconds for inactive targets
+	// Check every 10 seconds for inactive machines
 	ticker := p.clock.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
@@ -470,39 +496,39 @@ func (p *ProxyService) startInactivityMonitor(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C():
-			p.checkInactiveTargets()
+			p.checkInactiveMachines()
 		}
 	}
 }
 
-func (p *ProxyService) checkInactiveTargets() {
+func (p *ProxyService) checkInactiveMachines() {
 	now := p.clock.Now()
 
-	for name, targetState := range p.config.Targets {
-		// Skip targets without inactivity threshold
-		threshold, exists := p.config.InactivityThresholds[name]
-		if !exists {
+	for name, machineState := range p.config.Machines {
+		// Skip machines without inactivity threshold
+		threshold := machineState.Machine.InactivityThreshold
+		if threshold == 0 {
 			continue
 		}
 
-		// Skip targets that are not healthy (already down)
-		targetState.mu.RLock()
-		isHealthy := targetState.IsHealthy
-		lastActivity := targetState.LastActivity
-		targetState.mu.RUnlock()
+		// Skip machines that are not healthy (already down)
+		machineState.mu.RLock()
+		isHealthy := machineState.IsHealthy
+		lastActivity := machineState.LastActivity
+		machineState.mu.RUnlock()
 
 		if !isHealthy {
 			continue
 		}
 
-		// Check if the target has been inactive for too long
+		// Check if the machine has been inactive for too long
 		inactiveDuration := now.Sub(lastActivity)
 		if inactiveDuration > threshold {
-			p.logger.Info("Target %s has been inactive for %v (threshold: %v), shutting down",
+			p.logger.Info("Machine %s has been inactive for %v (threshold: %v), shutting down",
 				name, inactiveDuration.Round(time.Second), threshold)
 
-			if err := p.shutdownTarget(name); err != nil {
-				p.logger.Error("Failed to shut down inactive target %s: %v", name, err)
+			if err := p.shutdownMachine(name); err != nil {
+				p.logger.Error("Failed to shut down inactive machine %s: %v", name, err)
 			}
 		}
 	}
@@ -516,7 +542,7 @@ func (p *ProxyService) Start(ctx context.Context) error {
 	// Start background health checks
 	p.healthChecker.StartBackgroundChecks(
 		ctx,
-		p.config.Targets,
+		p.config.Machines,
 		p.config.HealthCheckInterval,
 	)
 
@@ -531,10 +557,10 @@ func (p *ProxyService) Start(ctx context.Context) error {
 
 	p.logger.Info("Initial health checks completed, starting HTTP server")
 
-	// Log configured targets
-	for name, target := range p.config.Targets {
-		p.logger.Info("Configured target: %s -> %s (%s)",
-			target.Target.Hostname, name, target.Target.Destination)
+	// Log configured routes
+	for _, route := range p.config.Routes {
+		p.logger.Info("Configured route: %s -> %s (%s)",
+			route.Hostname, route.Machine.Machine.Name, route.Destination)
 	}
 
 	// Start HTTP/HTTPS server
@@ -574,75 +600,66 @@ func (p *ProxyService) Start(ctx context.Context) error {
 }
 
 func (p *ProxyService) handleRequest(w http.ResponseWriter, r *http.Request) {
-	targetName := p.extractTarget(r)
+	route := p.routeForRequest(r)
 
-	if targetName == "" {
-		p.logger.Error("No target found for hostname: %s", r.Host)
-		http.Error(w, "No target configured for this hostname", http.StatusNotFound)
+	if route == nil {
+		p.logger.Error("No route found for hostname: %s", r.Host)
+		http.Error(w, "No route configured for this hostname", http.StatusNotFound)
 		return
 	}
 
-	p.logger.Info("Incoming request for hostname: %s -> target: %s, path: %s",
-		r.Host, targetName, r.URL.Path)
+	machineState := route.Machine
+	machineName := machineState.Machine.Name
 
-	targetState, exists := p.config.Targets[targetName]
-	if !exists {
-		p.logger.Error("Unknown target: %s", targetName)
-		http.Error(w, "Target not found", http.StatusNotFound)
-		return
-	}
+	p.logger.Info("Incoming request for hostname: %s -> machine: %s, path: %s",
+		r.Host, machineName, r.URL.Path)
 
 	// Check if we have fresh health data
-	cached, reason := p.healthCacheStatus(targetState)
+	cached, reason := p.healthCacheStatus(machineState)
 	if cached {
-		p.logger.Info("Target %s is healthy, proxying immediately", targetName)
-		p.proxyRequest(w, r, targetState.Target)
+		p.logger.Info("Machine %s is healthy, proxying immediately", machineName)
+		p.proxyRequest(w, r, route)
 		return
 	}
 
 	// Need to wake up the server
-	p.logger.Info("Target %s appears down (%s), attempting to wake", targetName, reason)
+	p.logger.Info("Machine %s appears down (%s), attempting to wake", machineName, reason)
 	p.healthChecker.CloseIdleConnections()
-	if err := p.wakeAndWait(r.Context(), targetState); err != nil {
-		p.logger.Error("Failed to wake target %s: %v", targetName, err)
+	if err := p.wakeAndWait(r.Context(), machineState); err != nil {
+		p.logger.Error("Failed to wake machine %s: %v", machineName, err)
 		http.Error(w, "Service temporarily unavailable", http.StatusServiceUnavailable)
 		return
 	}
 
-	p.logger.Info("Target %s is now healthy, proxying request", targetName)
-	p.proxyRequest(w, r, targetState.Target)
+	p.logger.Info("Machine %s is now healthy, proxying request", machineName)
+	p.proxyRequest(w, r, route)
 }
 
-func (p *ProxyService) extractTarget(r *http.Request) string {
+func (p *ProxyService) routeForRequest(r *http.Request) *Route {
 	// Remove port from host if present
 	host := r.Host
 	if colonIndex := strings.Index(host, ":"); colonIndex != -1 {
 		host = host[:colonIndex]
 	}
 
-	// Look up target by hostname
-	if targetName, exists := p.config.HostnameMap[host]; exists {
-		return targetName
-	}
-
-	return ""
+	return p.config.RoutesByHostname[host]
 }
 
-func (p *ProxyService) healthCacheStatus(target *TargetState) (cached bool, reason string) {
-	target.mu.RLock()
-	defer target.mu.RUnlock()
+func (p *ProxyService) healthCacheStatus(machine *MachineState) (cached bool, reason string) {
+	machine.mu.RLock()
+	defer machine.mu.RUnlock()
 
-	if !target.IsHealthy {
-		if target.LastCheck.IsZero() {
+	if !machine.IsHealthy {
+		if machine.LastCheck.IsZero() {
 			return false, "no prior health check"
 		}
 		return false, fmt.Sprintf(
 			"marked unhealthy (last check %v ago)",
-			p.clock.Now().Sub(target.LastCheck).Round(time.Second),
+			p.clock.Now().Sub(machine.LastCheck).Round(time.Second),
 		)
 	}
 
-	age := p.clock.Now().Sub(target.LastCheck)
+	age := p.clock.Now().Sub(machine.LastCheck)
 	if age > p.config.HealthCacheDuration {
 		return false, fmt.Sprintf(
 			"cached health expired (last check %v ago, cache duration %v)",
@@ -653,45 +670,45 @@ func (p *ProxyService) healthCacheStatus(target *TargetState) (cached bool, reas
 	return true, ""
 }
 
-func (p *ProxyService) wakeAndWait(ctx context.Context, target *TargetState) error {
-	target.mu.Lock()
-	if target.IsWaking {
-		target.mu.Unlock()
-		p.logger.Info("Target %s (%s) wake already in progress, joining existing wait",
-			target.Target.Name, target.Target.Hostname)
-		return p.waitForWake(ctx, target)
+func (p *ProxyService) wakeAndWait(ctx context.Context, machine *MachineState) error {
+	machine.mu.Lock()
+	if machine.IsWaking {
+		machine.mu.Unlock()
+		p.logger.Info("Machine %s wake already in progress, joining existing wait",
+			machine.Machine.Name)
+		return p.waitForWake(ctx, machine)
 	}
 
-	target.IsWaking = true
-	target.mu.Unlock()
+	machine.IsWaking = true
+	machine.mu.Unlock()
 
 	defer func() {
-		target.mu.Lock()
-		target.IsWaking = false
-		target.mu.Unlock()
+		machine.mu.Lock()
+		machine.IsWaking = false
+		machine.mu.Unlock()
 	}()
 
 	err := p.wolSender.SendWOL(
-		target.Target.MacAddress,
-		target.Target.BroadcastIP,
-		target.Target.WolPort,
+		machine.Machine.MacAddress,
+		machine.Machine.BroadcastIP,
+		machine.Machine.WolPort,
 	)
 
-	target.mu.Lock()
-	target.LastActivity = p.clock.Now()
-	target.mu.Unlock()
+	machine.mu.Lock()
+	machine.LastActivity = p.clock.Now()
+	machine.mu.Unlock()
 
 	if err != nil {
 		return fmt.Errorf("failed to send WOL: %w", err)
 	}
 
-	p.logger.Info("WOL packet sent to %s (%s), waiting for server to wake",
-		target.Target.Name, target.Target.Hostname)
+	p.logger.Info("WOL packet sent to %s, waiting for server to wake",
+		machine.Machine.Name)
 
-	return p.waitForWake(ctx, target)
+	return p.waitForWake(ctx, machine)
 }
 
-func (p *ProxyService) waitForWake(ctx context.Context, target *TargetState) error {
+func (p *ProxyService) waitForWake(ctx context.Context, machine *MachineState) error {
 	timeout := p.clock.After(p.config.Timeout)
 	healthCheckTicker := p.clock.NewTicker(p.config.PollInterval)
 	defer healthCheckTicker.Stop()
@@ -700,8 +717,8 @@ func (p *ProxyService) waitForWake(ctx context.Context, target *TargetState) err
 	defer wolTicker.Stop()
 
 	wakeStartTime := p.clock.Now()
-	p.logger.Info("Waiting for %s (%s) to wake (poll interval %v, timeout %v)",
-		target.Target.Name, target.Target.Hostname, p.config.PollInterval, p.config.Timeout)
+	p.logger.Info("Waiting for %s to wake (poll interval %v, timeout %v)",
+		machine.Machine.Name, p.config.PollInterval, p.config.Timeout)
 
 	for {
 		select {
@@ -709,47 +726,46 @@ func (p *ProxyService) waitForWake(ctx context.Context, target *TargetState) err
 			return ctx.Err()
 		case <-timeout:
 			return fmt.Errorf("timeout waiting for %s to wake up after %v",
-				target.Target.Name, p.config.Timeout)
+				machine.Machine.Name, p.config.Timeout)
 		case <-wolTicker.C():
 			// Send additional WOL packets while waiting
 			err := p.wolSender.SendWOL(
-				target.Target.MacAddress,
-				target.Target.BroadcastIP,
-				target.Target.WolPort,
+				machine.Machine.MacAddress,
+				machine.Machine.BroadcastIP,
+				machine.Machine.WolPort,
 			)
 			if err != nil {
 				p.logger.Error("Failed to send additional WOL packet: %v", err)
 				// Continue waiting even if a packet fails to send
 			} else {
-				p.logger.Info("Sent additional WOL packet to %s (%s)",
-					target.Target.Name, target.Target.Hostname)
+				p.logger.Info("Sent additional WOL packet to %s",
+					machine.Machine.Name)
 			}
 		case <-healthCheckTicker.C():
-			if p.healthChecker.Check(ctx, target.Target.HealthEndpoint, "wake") {
-				target.mu.Lock()
-				target.IsHealthy = true
-				target.LastCheck = p.clock.Now()
-				target.mu.Unlock()
+			if p.healthChecker.Check(ctx, machine.Machine.HealthCheck, "wake") {
+				machine.mu.Lock()
+				machine.IsHealthy = true
+				machine.LastCheck = p.clock.Now()
+				machine.mu.Unlock()
 
 				wakeDuration := p.clock.Now().Sub(wakeStartTime)
-				p.logger.Info("Target %s (%s) woke up after %v",
-					target.Target.Name, target.Target.Hostname, wakeDuration)
+				p.logger.Info("Machine %s woke up after %v",
+					machine.Machine.Name, wakeDuration)
 				return nil
 			}
 		}
 	}
 }
 
-func (p *ProxyService) proxyRequest(w http.ResponseWriter, r *http.Request, target *Target) {
-	if targetState, exists := p.config.Targets[target.Name]; exists {
-		targetState.mu.Lock()
-		targetState.LastActivity = p.clock.Now()
-		targetState.mu.Unlock()
-	}
+func (p *ProxyService) proxyRequest(w http.ResponseWriter, r *http.Request, route *Route) {
+	machineState := route.Machine
+	machineState.mu.Lock()
+	machineState.LastActivity = p.clock.Now()
+	machineState.mu.Unlock()
 
-	targetURL, err := url.Parse(target.Destination)
+	targetURL, err := url.Parse(route.Destination)
 	if err != nil {
-		p.logger.Error("Invalid target URL %s: %v", target.Destination, err)
+		p.logger.Error("Invalid target URL %s: %v", route.Destination, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -771,7 +787,7 @@ func (p *ProxyService) proxyRequest(w http.ResponseWriter, r *http.Request, targ
 		ExpectContinueTimeout: 5 * time.Second,   // Increased expect-continue timeout
 		MaxIdleConnsPerHost:   10,
 		// Disable compression to avoid issues with already compressed data
-		DisableCompression: true,
+		DisableCompression:    true,
 		ResponseHeaderTimeout: p.config.ResponseHeaderTimeout,
 		// No timeout for reading the entire response
 		ReadBufferSize:  1024 * 1024, // 1MB buffer for reading
@@ -799,14 +815,14 @@ func (p *ProxyService) proxyRequest(w http.ResponseWriter, r *http.Request, targ
 	}
 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
-		p.logger.Error("Proxy error for %s (%s): %v", target.Name, target.Hostname, err)
+		p.logger.Error("Proxy error for %s (%s): %v", route.Machine.Machine.Name, route.Hostname, err)
 		http.Error(rw, "Bad Gateway", http.StatusBadGateway)
 	}
 
 	// Disable buffering of response body for streaming uploads/downloads
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		p.logger.Info("Response from %s: status=%d, content-length=%d",
-			target.Name, resp.StatusCode, resp.ContentLength)
+			route.Name, resp.StatusCode, resp.ContentLength)
 		return nil
 	}
 
@@ -861,47 +877,68 @@ func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 		return nil, fmt.Errorf("invalid health_cache_duration: %w", err)
 	}
 
-	targets := make(map[string]*TargetState)
-	hostnameMap := make(map[string]string)
-	inactivityThresholds := make(map[string]time.Duration)
+	machines := make(map[string]*MachineState)
+	routes := make([]*Route, 0, len(config.Targets))
+	routesByHostname := make(map[string]*Route)
 
-    for _, target := range config.Targets {
-        if target.Hostname == "" {
-            return nil, fmt.Errorf("target %s is missing hostname", target.Name)
-        }
+	for _, target := range config.Targets {
+		if target.Hostname == "" {
+			return nil, fmt.Errorf("target %s is missing hostname", target.Name)
+		}
 
 		// Check for duplicate hostnames
-		if existingTarget, exists := hostnameMap[target.Hostname]; exists {
+		if existing, exists := routesByHostname[target.Hostname]; exists {
 			return nil, fmt.Errorf("duplicate hostname %s for targets %s and %s",
-				target.Hostname, existingTarget, target.Name)
+				target.Hostname, existing.Name, target.Name)
 		}
 
-        // Validate shutdown configuration
-        // Disallow using both SSH shutdown command and HTTP shutdown URL
-        if strings.TrimSpace(target.ShutdownHTTPUrl) != "" && strings.TrimSpace(target.ShutdownCommand) != "" {
-            return nil, fmt.Errorf("target %s: cannot define both shutdown_http_url and shutdown_command; choose one", target.Name)
-        }
-
-        // Disallow http method/ok status without URL
-        if strings.TrimSpace(target.ShutdownHTTPUrl) == "" && (strings.TrimSpace(target.ShutdownHTTPMethod) != "" || target.ShutdownHTTPOKStatus != 0) {
-            return nil, fmt.Errorf("target %s: shutdown_http_method and/or shutdown_http_ok_status require shutdown_http_url to be set", target.Name)
-        }
-
-        // Parse inactivity threshold if provided
-        if target.InactivityThreshold != "" {
-            inactivityThreshold, err := time.ParseDuration(target.InactivityThreshold)
-            if err != nil {
-                return nil, fmt.Errorf("invalid inactivity_threshold for target %s: %w", target.Name, err)
-            }
-			inactivityThresholds[target.Name] = inactivityThreshold
+		// Validate shutdown configuration
+		// Disallow using both SSH shutdown command and HTTP shutdown URL
+		if strings.TrimSpace(target.ShutdownHTTPUrl) != "" && strings.TrimSpace(target.ShutdownCommand) != "" {
+			return nil, fmt.Errorf("target %s: cannot define both shutdown_http_url and shutdown_command; choose one", target.Name)
 		}
 
-		targetCopy := target
-		targets[target.Name] = &TargetState{
-			Target:       &targetCopy,
+		// Disallow http method/ok status without URL
+		if strings.TrimSpace(target.ShutdownHTTPUrl) == "" && (strings.TrimSpace(target.ShutdownHTTPMethod) != "" || target.ShutdownHTTPOKStatus != 0) {
+			return nil, fmt.Errorf("target %s: shutdown_http_method and/or shutdown_http_ok_status require shutdown_http_url to be set", target.Name)
+		}
+
+		var inactivityThreshold time.Duration
+		if target.InactivityThreshold != "" {
+			inactivityThreshold, err = time.ParseDuration(target.InactivityThreshold)
+			if err != nil {
+				return nil, fmt.Errorf("invalid inactivity_threshold for target %s: %w", target.Name, err)
+			}
+		}
+
+		machineState := &MachineState{
+			Machine: &Machine{
+				Name:                 target.Name,
+				MacAddress:           target.MacAddress,
+				BroadcastIP:          target.BroadcastIP,
+				WolPort:              target.WolPort,
+				HealthCheck:          target.HealthEndpoint,
+				SSHHost:              target.SSHHost,
+				SSHUser:              target.SSHUser,
+				SSHKeyPath:           target.SSHKeyPath,
+				ShutdownCommand:      target.ShutdownCommand,
+				ShutdownHTTPUrl:      target.ShutdownHTTPUrl,
+				ShutdownHTTPMethod:   target.ShutdownHTTPMethod,
+				ShutdownHTTPOKStatus: target.ShutdownHTTPOKStatus,
+				InactivityThreshold:  inactivityThreshold,
+			},
 			LastActivity: clock.Now(),
 		}
-		hostnameMap[target.Hostname] = target.Name
+		machines[target.Name] = machineState
+
+		route := &Route{
+			Name:        target.Name,
+			Machine:     machineState,
+			Hostname:    target.Hostname,
+			Destination: target.Destination,
+		}
+		routes = append(routes, route)
+		routesByHostname[target.Hostname] = route
 	}
 
 	return &ProxyConfig{
@@ -913,9 +950,9 @@ func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 		PollInterval:          pollInterval,
 		HealthCheckInterval:   healthCheckInterval,
 		HealthCacheDuration:   healthCacheDuration,
-		Targets:               targets,
-		HostnameMap:           hostnameMap,
-		InactivityThresholds:  inactivityThresholds,
+		Machines:              machines,
+		Routes:                routes,
+		RoutesByHostname:      routesByHostname,
 	}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 // Interfaces for dependency injection
 type HealthChecker interface {
 	Check(ctx context.Context, endpoint string, source string) bool
-	StartBackgroundChecks(ctx context.Context, machines map[string]*MachineState, interval time.Duration)
+	StartBackgroundChecks(ctx context.Context, machines map[string]*Machine, interval time.Duration)
 	WaitForInitialChecks(ctx context.Context) error
 	CloseIdleConnections()
 }
@@ -96,8 +96,7 @@ type Target struct {
 
 // Machine is a host that is woken, health-checked and shut down as one unit,
 // however many routes point at it.
-type Machine struct {
-	Name                 string
+type MachineConfig struct {
 	MacAddress           string
 	BroadcastIP          string
 	WolPort              int
@@ -115,7 +114,7 @@ type Machine struct {
 // Route is one way in to a machine.
 type Route struct {
 	Name        string
-	Machine     *MachineState
+	Machine     *Machine
 	Hostname    string
 	Destination string
 }
@@ -127,15 +126,16 @@ type ProxyConfig struct {
 	PollInterval          time.Duration
 	HealthCheckInterval   time.Duration
 	HealthCacheDuration   time.Duration
-	Machines              map[string]*MachineState
+	Machines              map[string]*Machine
 	Routes                []*Route
 	RoutesByHostname      map[string]*Route
 	SSLCertificate        string
 	SSLCertificateKey     string
 }
 
-type MachineState struct {
-	Machine      *Machine
+type Machine struct {
+	Name         string
+	Config       *MachineConfig
 	IsHealthy    bool
 	LastCheck    time.Time
 	IsWaking     bool
@@ -196,7 +196,7 @@ func (h *HTTPHealthChecker) Check(ctx context.Context, endpoint string, source s
 	return true
 }
 
-func (h *HTTPHealthChecker) StartBackgroundChecks(ctx context.Context, machines map[string]*MachineState, interval time.Duration) {
+func (h *HTTPHealthChecker) StartBackgroundChecks(ctx context.Context, machines map[string]*Machine, interval time.Duration) {
 	for name, machine := range machines {
 		h.initialWaitGroup.Add(1)
 		go h.backgroundCheck(ctx, name, machine, interval)
@@ -218,7 +218,7 @@ func (h *HTTPHealthChecker) WaitForInitialChecks(ctx context.Context) error {
 	}
 }
 
-func (h *HTTPHealthChecker) backgroundCheck(ctx context.Context, name string, machine *MachineState, interval time.Duration) {
+func (h *HTTPHealthChecker) backgroundCheck(ctx context.Context, name string, machine *Machine, interval time.Duration) {
 	// Perform initial check
 	h.performCheck(name, machine)
 	h.markInitialCheckDone(name)
@@ -237,20 +237,20 @@ func (h *HTTPHealthChecker) backgroundCheck(ctx context.Context, name string, ma
 	}
 }
 
-func (h *HTTPHealthChecker) performCheck(name string, machine *MachineState) {
+func (h *HTTPHealthChecker) performCheck(name string, machine *Machine) {
 	machine.mu.RLock()
 	isWaking := machine.IsWaking
 	machine.mu.RUnlock()
 	if isWaking {
 		h.logger.Info("Background health check for %s (%s) running while wake is in progress",
-			name, machine.Machine.HealthCheck)
+			name, machine.Config.HealthCheck)
 	}
 
 	checkStarted := h.clock.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	healthy := h.Check(ctx, machine.Machine.HealthCheck, "background")
+	healthy := h.Check(ctx, machine.Config.HealthCheck, "background")
 
 	machine.mu.Lock()
 	previousHealth := machine.IsHealthy
@@ -263,13 +263,13 @@ func (h *HTTPHealthChecker) performCheck(name string, machine *MachineState) {
 		if healthy {
 			status = "UP"
 		}
-		h.logger.Info("Health check for %s (%s): %s", name, machine.Machine.HealthCheck, status)
+		h.logger.Info("Health check for %s (%s): %s", name, machine.Config.HealthCheck, status)
 	}
 
 	if !healthy && previousHealth {
 		h.logger.Info(
 			"Background health check for %s (%s): downgrading healthy to unhealthy (check took %v)",
-			name, machine.Machine.HealthCheck, h.clock.Now().Sub(checkStarted).Round(time.Millisecond),
+			name, machine.Config.HealthCheck, h.clock.Now().Sub(checkStarted).Round(time.Millisecond),
 		)
 	}
 
@@ -431,20 +431,20 @@ func (p *ProxyService) shutdownMachine(machineName string) error {
 		return fmt.Errorf("unknown machine: %s", machineName)
 	}
 
-	machine := machineState.Machine
-	if (machine.SSHHost == "" || machine.SSHUser == "" || machine.SSHKeyPath == "" || machine.ShutdownCommand == "") && machine.ShutdownHTTPUrl == "" {
+	cfg := machineState.Config
+	if (cfg.SSHHost == "" || cfg.SSHUser == "" || cfg.SSHKeyPath == "" || cfg.ShutdownCommand == "") && cfg.ShutdownHTTPUrl == "" {
 		return fmt.Errorf("machine %s is missing SSH configuration or shutdown command or shutdown HTTP URL", machineName)
 	}
 
 	p.logger.Info("Shutting down machine %s due to inactivity", machineName)
-	if machine.ShutdownHTTPUrl != "" {
+	if cfg.ShutdownHTTPUrl != "" {
 		// Attempt to shut down via HTTP request
-		method := machine.ShutdownHTTPMethod
+		method := cfg.ShutdownHTTPMethod
 		if method == "" {
 			method = "POST" // Default to POST if not specified
 		}
 
-		req, err := http.NewRequest(method, machine.ShutdownHTTPUrl, nil)
+		req, err := http.NewRequest(method, cfg.ShutdownHTTPUrl, nil)
 		if err != nil {
 			return fmt.Errorf("failed to create shutdown request: %w", err)
 		}
@@ -460,8 +460,8 @@ func (p *ProxyService) shutdownMachine(machineName string) error {
 		defer resp.Body.Close()
 
 		// Accept any 2xx status by default; allow explicit status override
-		if machine.ShutdownHTTPOKStatus != 0 {
-			if resp.StatusCode != machine.ShutdownHTTPOKStatus {
+		if cfg.ShutdownHTTPOKStatus != 0 {
+			if resp.StatusCode != cfg.ShutdownHTTPOKStatus {
 				return fmt.Errorf("shutdown request failed with status: %s", resp.Status)
 			}
 		} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -469,7 +469,7 @@ func (p *ProxyService) shutdownMachine(machineName string) error {
 		}
 
 	} else {
-		err := p.sshExecutor.ExecuteCommand(machine.SSHHost, machine.SSHUser, machine.SSHKeyPath, machine.ShutdownCommand)
+		err := p.sshExecutor.ExecuteCommand(cfg.SSHHost, cfg.SSHUser, cfg.SSHKeyPath, cfg.ShutdownCommand)
 		if err != nil {
 			p.logger.Error("Failed to shut down machine %s: %v", machineName, err)
 			return err
@@ -506,7 +506,7 @@ func (p *ProxyService) checkInactiveMachines() {
 
 	for name, machineState := range p.config.Machines {
 		// Skip machines without inactivity threshold
-		threshold := machineState.Machine.InactivityThreshold
+		threshold := machineState.Config.InactivityThreshold
 		if threshold == 0 {
 			continue
 		}
@@ -560,7 +560,7 @@ func (p *ProxyService) Start(ctx context.Context) error {
 	// Log configured routes
 	for _, route := range p.config.Routes {
 		p.logger.Info("Configured route: %s -> %s (%s)",
-			route.Hostname, route.Machine.Machine.Name, route.Destination)
+			route.Hostname, route.Machine.Name, route.Destination)
 	}
 
 	// Start HTTP/HTTPS server
@@ -609,7 +609,7 @@ func (p *ProxyService) handleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	machineState := route.Machine
-	machineName := machineState.Machine.Name
+	machineName := machineState.Name
 
 	p.logger.Info("Incoming request for hostname: %s -> machine: %s, path: %s",
 		r.Host, machineName, r.URL.Path)
@@ -645,7 +645,7 @@ func (p *ProxyService) routeForRequest(r *http.Request) *Route {
 	return p.config.RoutesByHostname[host]
 }
 
-func (p *ProxyService) healthCacheStatus(machine *MachineState) (cached bool, reason string) {
+func (p *ProxyService) healthCacheStatus(machine *Machine) (cached bool, reason string) {
 	machine.mu.RLock()
 	defer machine.mu.RUnlock()
 
@@ -670,12 +670,12 @@ func (p *ProxyService) healthCacheStatus(machine *MachineState) (cached bool, re
 	return true, ""
 }
 
-func (p *ProxyService) wakeAndWait(ctx context.Context, machine *MachineState) error {
+func (p *ProxyService) wakeAndWait(ctx context.Context, machine *Machine) error {
 	machine.mu.Lock()
 	if machine.IsWaking {
 		machine.mu.Unlock()
 		p.logger.Info("Machine %s wake already in progress, joining existing wait",
-			machine.Machine.Name)
+			machine.Name)
 		return p.waitForWake(ctx, machine)
 	}
 
@@ -689,9 +689,9 @@ func (p *ProxyService) wakeAndWait(ctx context.Context, machine *MachineState) e
 	}()
 
 	err := p.wolSender.SendWOL(
-		machine.Machine.MacAddress,
-		machine.Machine.BroadcastIP,
-		machine.Machine.WolPort,
+		machine.Config.MacAddress,
+		machine.Config.BroadcastIP,
+		machine.Config.WolPort,
 	)
 
 	machine.mu.Lock()
@@ -703,12 +703,12 @@ func (p *ProxyService) wakeAndWait(ctx context.Context, machine *MachineState) e
 	}
 
 	p.logger.Info("WOL packet sent to %s, waiting for server to wake",
-		machine.Machine.Name)
+		machine.Name)
 
 	return p.waitForWake(ctx, machine)
 }
 
-func (p *ProxyService) waitForWake(ctx context.Context, machine *MachineState) error {
+func (p *ProxyService) waitForWake(ctx context.Context, machine *Machine) error {
 	timeout := p.clock.After(p.config.Timeout)
 	healthCheckTicker := p.clock.NewTicker(p.config.PollInterval)
 	defer healthCheckTicker.Stop()
@@ -718,7 +718,7 @@ func (p *ProxyService) waitForWake(ctx context.Context, machine *MachineState) e
 
 	wakeStartTime := p.clock.Now()
 	p.logger.Info("Waiting for %s to wake (poll interval %v, timeout %v)",
-		machine.Machine.Name, p.config.PollInterval, p.config.Timeout)
+		machine.Name, p.config.PollInterval, p.config.Timeout)
 
 	for {
 		select {
@@ -726,23 +726,23 @@ func (p *ProxyService) waitForWake(ctx context.Context, machine *MachineState) e
 			return ctx.Err()
 		case <-timeout:
 			return fmt.Errorf("timeout waiting for %s to wake up after %v",
-				machine.Machine.Name, p.config.Timeout)
+				machine.Name, p.config.Timeout)
 		case <-wolTicker.C():
 			// Send additional WOL packets while waiting
 			err := p.wolSender.SendWOL(
-				machine.Machine.MacAddress,
-				machine.Machine.BroadcastIP,
-				machine.Machine.WolPort,
+				machine.Config.MacAddress,
+				machine.Config.BroadcastIP,
+				machine.Config.WolPort,
 			)
 			if err != nil {
 				p.logger.Error("Failed to send additional WOL packet: %v", err)
 				// Continue waiting even if a packet fails to send
 			} else {
 				p.logger.Info("Sent additional WOL packet to %s",
-					machine.Machine.Name)
+					machine.Name)
 			}
 		case <-healthCheckTicker.C():
-			if p.healthChecker.Check(ctx, machine.Machine.HealthCheck, "wake") {
+			if p.healthChecker.Check(ctx, machine.Config.HealthCheck, "wake") {
 				machine.mu.Lock()
 				machine.IsHealthy = true
 				machine.LastCheck = p.clock.Now()
@@ -750,7 +750,7 @@ func (p *ProxyService) waitForWake(ctx context.Context, machine *MachineState) e
 
 				wakeDuration := p.clock.Now().Sub(wakeStartTime)
 				p.logger.Info("Machine %s woke up after %v",
-					machine.Machine.Name, wakeDuration)
+					machine.Name, wakeDuration)
 				return nil
 			}
 		}
@@ -815,7 +815,7 @@ func (p *ProxyService) proxyRequest(w http.ResponseWriter, r *http.Request, rout
 	}
 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, req *http.Request, err error) {
-		p.logger.Error("Proxy error for %s (%s): %v", route.Machine.Machine.Name, route.Hostname, err)
+		p.logger.Error("Proxy error for %s (%s): %v", route.Machine.Name, route.Hostname, err)
 		http.Error(rw, "Bad Gateway", http.StatusBadGateway)
 	}
 
@@ -877,7 +877,7 @@ func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 		return nil, fmt.Errorf("invalid health_cache_duration: %w", err)
 	}
 
-	machines := make(map[string]*MachineState)
+	machines := make(map[string]*Machine)
 	routes := make([]*Route, 0, len(config.Targets))
 	routesByHostname := make(map[string]*Route)
 
@@ -911,9 +911,9 @@ func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 			}
 		}
 
-		machineState := &MachineState{
-			Machine: &Machine{
-				Name:                 target.Name,
+		machineState := &Machine{
+			Name: target.Name,
+			Config: &MachineConfig{
 				MacAddress:           target.MacAddress,
 				BroadcastIP:          target.BroadcastIP,
 				WolPort:              target.WolPort,

--- a/main.go
+++ b/main.go
@@ -771,8 +771,16 @@ func (p *ProxyService) Start(ctx context.Context) error {
 
 // serveHTTP serves until the context is cancelled, then drains in-flight requests
 // before returning. A clean shutdown is not an error.
+//
+// server.Shutdown closes the listener first, which unblocks server.Serve() with
+// http.ErrServerClosed while Shutdown is still waiting on active handlers.
+// Returning on ErrServerClosed alone would let main exit before the grace window
+// finishes and cut every in-flight response, so wait for the shutdown goroutine
+// too.
 func (p *ProxyService) serveHTTP(ctx context.Context, server *http.Server, listener net.Listener) error {
+	shutdownDone := make(chan struct{})
 	go func() {
+		defer close(shutdownDone)
 		<-ctx.Done()
 
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
@@ -784,6 +792,7 @@ func (p *ProxyService) serveHTTP(ctx context.Context, server *http.Server, liste
 
 	err := p.serveOn(server, listener)
 	if errors.Is(err, http.ErrServerClosed) {
+		<-shutdownDone
 		return nil
 	}
 	return err

--- a/main.go
+++ b/main.go
@@ -1042,6 +1042,14 @@ func (p *ProxyService) forwardTCPConn(ctx context.Context, client net.Conn, rout
 		}
 	}
 
+	if cached, reason := p.readyCacheStatus(route); !cached {
+		p.logger.Info("Route %s not ready (%s), waiting before forwarding", route.Name, reason)
+		if err := p.waitForReady(ctx, route); err != nil {
+			p.logger.Error("Route %s did not become ready: %v", route.Name, err)
+			return
+		}
+	}
+
 	upstream, err := net.Dial("tcp", route.Destination)
 	if err != nil {
 		p.logger.Error("Could not reach %s for route %s: %v", route.Destination, route.Name, err)

--- a/main.go
+++ b/main.go
@@ -725,9 +725,16 @@ func (p *ProxyService) Start(ctx context.Context) error {
 			route.Name, route.Machine.Name, route.Destination)
 	}
 
+	// A failure in any one server winds down the rest, so that the first real error
+	// is what Start reports rather than whichever goroutine happens to notice the
+	// shutdown first.
+	ctx, cancelServers := context.WithCancel(ctx)
+	defer cancelServers()
+
 	// Bind every TCP route before serving anything, so a port clash is reported at
 	// startup rather than leaving the proxy half up.
 	errs := make(chan error, len(p.config.Routes)+1)
+	servers := 0
 	for _, route := range p.config.Routes {
 		if !route.IsTCP() {
 			continue
@@ -740,6 +747,7 @@ func (p *ProxyService) Start(ctx context.Context) error {
 		}
 		defer listener.Close()
 
+		servers++
 		go func(listener net.Listener, route *Route) {
 			errs <- p.serveTCPRoute(ctx, listener, route)
 		}(listener, route)
@@ -764,9 +772,21 @@ func (p *ProxyService) Start(ctx context.Context) error {
 		return fmt.Errorf("could not listen on %s: %w", p.config.Port, err)
 	}
 
+	servers++
 	go func() { errs <- p.serveHTTP(ctx, server, httpListener) }()
 
-	return <-errs
+	// Wait for every server, not just the first to finish. serveTCPRoute returns nil
+	// microseconds after cancellation, while serveHTTP is still draining in-flight
+	// requests for up to shutdownGrace; returning on that first nil would cut every
+	// response that the drain exists to protect.
+	var firstErr error
+	for i := 0; i < servers; i++ {
+		if err := <-errs; err != nil && firstErr == nil {
+			firstErr = err
+			cancelServers()
+		}
+	}
+	return firstErr
 }
 
 // serveHTTP serves until the context is cancelled, then drains in-flight requests

--- a/main.go
+++ b/main.go
@@ -1531,6 +1531,32 @@ func migrateLegacyTargets(targets []Target) ([]MachineEntry, []RouteEntry) {
 // and url.Parse accepts far too much: "nas.local:2342" parses as scheme "nas.local"
 // with opaque body "2342" — dots are legal in scheme names — yielding a proxy that
 // 502s every request with nothing in the logs to explain it.
+// validateHealthCheck rejects a check the checker cannot actually perform. Check
+// dispatches on the scheme — tcp:// dials, anything else is handed to an HTTP client
+// — so a bare "nas.local:22" parses as a URL with scheme "nas.local" and fails every
+// time, leaving the machine permanently unhealthy exactly as an empty value would.
+func validateHealthCheck(label, value string) error {
+	if address, ok := strings.CutPrefix(value, tcpScheme); ok {
+		if _, _, err := net.SplitHostPort(address); err != nil {
+			return fmt.Errorf("%s: health check %q must be tcp://host:port: %w", label, value, err)
+		}
+		return nil
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("%s: invalid health check %q: %w", label, value, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf(
+			"%s: health check %q must be a tcp://, http:// or https:// URL", label, value)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("%s: health check %q has no host", label, value)
+	}
+	return nil
+}
+
 func validateDestination(name, destination string, isTCP bool) error {
 	if strings.TrimSpace(destination) == "" {
 		return fmt.Errorf("route %s needs a destination", name)
@@ -1585,6 +1611,9 @@ func buildMachinesAndRoutes(machineEntries []MachineEntry, routeEntries []RouteE
 			return routing{}, fmt.Errorf(
 				"machine %s needs a %s: it is how the proxy tells whether the box is up",
 				entry.Name, key)
+		}
+		if err := validateHealthCheck("machine "+entry.Name, entry.HealthCheck); err != nil {
+			return routing{}, err
 		}
 
 		// Disallow using both SSH shutdown command and HTTP shutdown URL
@@ -1665,6 +1694,10 @@ func buildMachinesAndRoutes(machineEntries []MachineEntry, routeEntries []RouteE
 			if err != nil {
 				return routing{}, fmt.Errorf("route %s: %w", name, err)
 			}
+		} else if err := validateHealthCheck("route "+name, healthCheck); err != nil {
+			// Only an explicit check can be malformed; a derived one is always
+			// tcp://host:port by construction.
+			return routing{}, err
 		}
 
 		route := &Route{

--- a/main.go
+++ b/main.go
@@ -319,7 +319,7 @@ func (h *EndpointHealthChecker) WaitForInitialChecks(ctx context.Context) error 
 
 func (h *EndpointHealthChecker) backgroundCheck(ctx context.Context, name string, machine *Machine, routes []*Route, interval time.Duration) {
 	// Perform initial check
-	h.performCheck(name, machine, routes)
+	h.performCheck(ctx, name, machine, routes)
 	h.markInitialCheckDone(name)
 	h.initialWaitGroup.Done()
 
@@ -331,12 +331,12 @@ func (h *EndpointHealthChecker) backgroundCheck(ctx context.Context, name string
 		case <-ctx.Done():
 			return
 		case <-ticker.C():
-			h.performCheck(name, machine, routes)
+			h.performCheck(ctx, name, machine, routes)
 		}
 	}
 }
 
-func (h *EndpointHealthChecker) performCheck(name string, machine *Machine, routes []*Route) {
+func (h *EndpointHealthChecker) performCheck(ctx context.Context, name string, machine *Machine, routes []*Route) {
 	machine.mu.RLock()
 	isWaking := machine.IsWaking
 	machine.mu.RUnlock()
@@ -346,10 +346,10 @@ func (h *EndpointHealthChecker) performCheck(name string, machine *Machine, rout
 	}
 
 	checkStarted := h.clock.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	healthy := h.Check(ctx, machine.Config.HealthCheck, "background")
+	healthy := h.Check(checkCtx, machine.Config.HealthCheck, "background")
 
 	machine.mu.Lock()
 	previousHealth := machine.IsHealthy
@@ -376,13 +376,13 @@ func (h *EndpointHealthChecker) performCheck(name string, machine *Machine, rout
 		h.CloseIdleConnections()
 	}
 
-	h.checkRoutes(machine, routes, healthy)
+	h.checkRoutes(ctx, machine, routes, healthy)
 }
 
 // checkRoutes polls each route's readiness, but only while its machine is live. A
 // machine that is meant to be asleep most of the time would otherwise generate a
 // failed connection per route per interval, forever.
-func (h *EndpointHealthChecker) checkRoutes(machine *Machine, routes []*Route, machineLive bool) {
+func (h *EndpointHealthChecker) checkRoutes(ctx context.Context, machine *Machine, routes []*Route, machineLive bool) {
 	for _, route := range routes {
 		if !machineLive {
 			route.mu.Lock()
@@ -391,8 +391,8 @@ func (h *EndpointHealthChecker) checkRoutes(machine *Machine, routes []*Route, m
 			continue
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		ready := h.Check(ctx, route.HealthCheck, "background")
+		checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ready := h.Check(checkCtx, route.HealthCheck, "background")
 		cancel()
 
 		route.mu.Lock()
@@ -1065,7 +1065,8 @@ func (p *ProxyService) forwardTCPConn(ctx context.Context, client net.Conn, rout
 		}
 	}
 
-	upstream, err := net.Dial("tcp", route.Destination)
+	dialer := net.Dialer{Timeout: p.config.Timeout}
+	upstream, err := dialer.DialContext(ctx, "tcp", route.Destination)
 	if err != nil {
 		p.logger.Error("Could not reach %s for route %s: %v", route.Destination, route.Name, err)
 		return
@@ -1079,17 +1080,27 @@ func (p *ProxyService) forwardTCPConn(ctx context.Context, client net.Conn, rout
 	machine.holdConnection()
 	defer machine.releaseConnection()
 
-	done := make(chan struct{}, 2)
+	// Both directions must finish before the deferred closes run. A client that
+	// half-closes its write side — ssh and scp both do, once the request is sent —
+	// ends one direction while the response is still streaming back on the other.
+	var copies sync.WaitGroup
+	copies.Add(2)
 	splice := func(dst, src net.Conn) {
+		defer copies.Done()
 		io.Copy(dst, src)
-		// Let the other direction drain rather than tearing the pair down mid-write.
+		// Half-close so the peer sees EOF while the other direction still drains.
 		if conn, ok := dst.(*net.TCPConn); ok {
 			conn.CloseWrite()
 		}
-		done <- struct{}{}
 	}
 	go splice(upstream, client)
 	go splice(client, upstream)
+
+	done := make(chan struct{})
+	go func() {
+		copies.Wait()
+		close(done)
+	}()
 
 	select {
 	case <-done:

--- a/main.go
+++ b/main.go
@@ -51,6 +51,12 @@ const tcpScheme = "tcp://"
 // shutdownGrace is how long in-flight requests get to finish on shutdown.
 const shutdownGrace = 15 * time.Second
 
+// healthCheckTimeout caps a single health check, HTTP or TCP alike. The TCP cap has
+// to live on the dialer rather than relying on the caller's context: waitForWake and
+// markReadyIfHealthy pass their caller's context through undeadlined, and a dropped
+// SYN would otherwise block for the kernel's whole retry schedule.
+const healthCheckTimeout = 5 * time.Second
+
 type Ticker interface {
 	C() <-chan time.Time
 	Stop()
@@ -237,6 +243,7 @@ func (m *Machine) releaseConnection(now time.Time) {
 type EndpointHealthChecker struct {
 	client           *http.Client
 	logger           Logger
+	dialer           net.Dialer
 	clock            Clock
 	initialCheckDone map[string]bool
 	initialCheckMu   sync.RWMutex
@@ -249,9 +256,10 @@ func NewEndpointHealthChecker(logger Logger, clock Clock) *EndpointHealthChecker
 	}
 	return &EndpointHealthChecker{
 		client: &http.Client{
-			Timeout:   5 * time.Second,
+			Timeout:   healthCheckTimeout,
 			Transport: transport,
 		},
+		dialer:           net.Dialer{Timeout: healthCheckTimeout},
 		logger:           logger,
 		clock:            clock,
 		initialCheckDone: make(map[string]bool),
@@ -275,8 +283,7 @@ func (h *EndpointHealthChecker) Check(ctx context.Context, endpoint string, sour
 // anything that is not an HTTP server — sshd being the motivating case — accepting
 // a connection is the only readiness signal there is.
 func (h *EndpointHealthChecker) checkTCP(ctx context.Context, address string, source string) bool {
-	var dialer net.Dialer
-	conn, err := dialer.DialContext(ctx, "tcp", address)
+	conn, err := h.dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
 		h.logger.Info("Health check (%s) failed for %s%s: %v", source, tcpScheme, address, err)
 		return false
@@ -358,7 +365,7 @@ func (h *EndpointHealthChecker) performCheck(ctx context.Context, name string, m
 	}
 
 	checkStarted := h.clock.Now()
-	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	checkCtx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
 	defer cancel()
 
 	healthy := h.Check(checkCtx, machine.Config.HealthCheck, "background")
@@ -403,7 +410,7 @@ func (h *EndpointHealthChecker) checkRoutes(ctx context.Context, machine *Machin
 			continue
 		}
 
-		checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		checkCtx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
 		ready := h.Check(checkCtx, route.HealthCheck, "background")
 		cancel()
 

--- a/main.go
+++ b/main.go
@@ -845,7 +845,7 @@ func (p *ProxyService) handleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Need to wake up the server
-	p.logger.Info("Machine %s appears down (%s), attempting to wake", machineName, reason)
+	p.logger.Info("Machine %s appears down (%s), waking for %s", machineName, reason, route.Name)
 	p.healthChecker.CloseIdleConnections()
 	if err := p.wakeAndWait(r.Context(), machineState); err != nil {
 		p.logger.Error("Failed to wake machine %s: %v", machineName, err)

--- a/main.go
+++ b/main.go
@@ -57,6 +57,26 @@ const shutdownGrace = 15 * time.Second
 // SYN would otherwise block for the kernel's whole retry schedule.
 const healthCheckTimeout = 5 * time.Second
 
+// A retried accept backs off between attempts, so a listener that is failing for a
+// reason we cannot fix does not spin a core while it recovers.
+const (
+	acceptRetryDelayMin = 5 * time.Millisecond
+	acceptRetryDelayMax = 1 * time.Second
+)
+
+// isTemporaryAcceptError reports whether an Accept failure is worth retrying. These
+// are conditions a listener recovers from unaided: a client that reset during the
+// handshake, or the process briefly out of descriptors or buffers. Anything else
+// means the listener is broken, and that has to reach the operator rather than
+// becoming a silent retry loop.
+func isTemporaryAcceptError(err error) bool {
+	return errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.EMFILE) ||
+		errors.Is(err, syscall.ENFILE) ||
+		errors.Is(err, syscall.ENOBUFS) ||
+		errors.Is(err, syscall.ENOMEM)
+}
+
 type Ticker interface {
 	C() <-chan time.Time
 	Stop()
@@ -1109,14 +1129,39 @@ func (p *ProxyService) serveTCPRoute(ctx context.Context, listener net.Listener,
 	p.logger.Info("Listening on %s for machine %s -> %s",
 		listener.Addr(), route.Machine.Name, route.Destination)
 
+	delay := time.Duration(0)
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil
 			}
-			return fmt.Errorf("accept on %s failed: %w", listener.Addr(), err)
+			if !isTemporaryAcceptError(err) {
+				return fmt.Errorf("accept on %s failed: %w", listener.Addr(), err)
+			}
+
+			// Back off rather than spinning, and keep serving: this route failing
+			// hard would propagate to main and take every other route down with it.
+			if delay == 0 {
+				delay = acceptRetryDelayMin
+			} else {
+				delay *= 2
+			}
+			if delay > acceptRetryDelayMax {
+				delay = acceptRetryDelayMax
+			}
+			p.logger.Error("Accept on %s failed (%v), retrying in %v",
+				listener.Addr(), err, delay)
+
+			select {
+			case <-p.clock.After(delay):
+			case <-ctx.Done():
+				return nil
+			}
+			continue
 		}
+
+		delay = 0
 		go p.forwardTCPConn(ctx, conn, route)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -821,6 +821,18 @@ func (p *ProxyService) serveOn(server *http.Server, listener net.Listener) error
 	}
 }
 
+// clientAddr describes where a request came from, for the log. RemoteAddr is the
+// peer that actually opened the connection, which is the fronting reverse proxy
+// when there is one, so an X-Forwarded-For it set is reported alongside RemoteAddr
+// rather than in place of it. That header is written by the caller and is only as
+// trustworthy as the hop that wrote it — fine for reading logs, not for decisions.
+func clientAddr(r *http.Request) string {
+	if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+		return fmt.Sprintf("%s (forwarded for %s)", r.RemoteAddr, forwarded)
+	}
+	return r.RemoteAddr
+}
+
 func (p *ProxyService) handleRequest(w http.ResponseWriter, r *http.Request) {
 	route := p.routeForRequest(r)
 
@@ -833,8 +845,8 @@ func (p *ProxyService) handleRequest(w http.ResponseWriter, r *http.Request) {
 	machineState := route.Machine
 	machineName := machineState.Name
 
-	p.logger.Info("Incoming request for hostname: %s -> machine: %s, path: %s",
-		r.Host, machineName, r.URL.Path)
+	p.logger.Info("Incoming request for hostname: %s -> machine: %s, path: %s, client: %s",
+		r.Host, machineName, r.URL.Path, clientAddr(r))
 
 	// Check if we have fresh health data
 	cached, reason := p.healthCacheStatus(machineState)

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 // Interfaces for dependency injection
 type HealthChecker interface {
 	Check(ctx context.Context, endpoint string, source string) bool
-	StartBackgroundChecks(ctx context.Context, machines map[string]*Machine, interval time.Duration)
+	StartBackgroundChecks(ctx context.Context, machines map[string]*Machine, routes []*Route, interval time.Duration)
 	WaitForInitialChecks(ctx context.Context) error
 	CloseIdleConnections()
 }
@@ -153,6 +153,10 @@ type Route struct {
 	// distinct from the machine's liveness check, which answers whether the box is
 	// up at all. Defaults to dialing Destination.
 	HealthCheck string
+
+	IsReady   bool
+	LastCheck time.Time
+	mu        sync.RWMutex
 }
 
 // IsTCP reports whether this route is reached by its own listening socket rather
@@ -266,10 +270,10 @@ func (h *EndpointHealthChecker) checkHTTP(ctx context.Context, endpoint string, 
 	return true
 }
 
-func (h *EndpointHealthChecker) StartBackgroundChecks(ctx context.Context, machines map[string]*Machine, interval time.Duration) {
+func (h *EndpointHealthChecker) StartBackgroundChecks(ctx context.Context, machines map[string]*Machine, routes []*Route, interval time.Duration) {
 	for name, machine := range machines {
 		h.initialWaitGroup.Add(1)
-		go h.backgroundCheck(ctx, name, machine, interval)
+		go h.backgroundCheck(ctx, name, machine, routesTo(machine, routes), interval)
 	}
 }
 
@@ -288,9 +292,9 @@ func (h *EndpointHealthChecker) WaitForInitialChecks(ctx context.Context) error 
 	}
 }
 
-func (h *EndpointHealthChecker) backgroundCheck(ctx context.Context, name string, machine *Machine, interval time.Duration) {
+func (h *EndpointHealthChecker) backgroundCheck(ctx context.Context, name string, machine *Machine, routes []*Route, interval time.Duration) {
 	// Perform initial check
-	h.performCheck(name, machine)
+	h.performCheck(name, machine, routes)
 	h.markInitialCheckDone(name)
 	h.initialWaitGroup.Done()
 
@@ -302,12 +306,12 @@ func (h *EndpointHealthChecker) backgroundCheck(ctx context.Context, name string
 		case <-ctx.Done():
 			return
 		case <-ticker.C():
-			h.performCheck(name, machine)
+			h.performCheck(name, machine, routes)
 		}
 	}
 }
 
-func (h *EndpointHealthChecker) performCheck(name string, machine *Machine) {
+func (h *EndpointHealthChecker) performCheck(name string, machine *Machine, routes []*Route) {
 	machine.mu.RLock()
 	isWaking := machine.IsWaking
 	machine.mu.RUnlock()
@@ -346,6 +350,51 @@ func (h *EndpointHealthChecker) performCheck(name string, machine *Machine) {
 	if !healthy {
 		h.CloseIdleConnections()
 	}
+
+	h.checkRoutes(machine, routes, healthy)
+}
+
+// checkRoutes polls each route's readiness, but only while its machine is live. A
+// machine that is meant to be asleep most of the time would otherwise generate a
+// failed connection per route per interval, forever.
+func (h *EndpointHealthChecker) checkRoutes(machine *Machine, routes []*Route, machineLive bool) {
+	for _, route := range routes {
+		if !machineLive {
+			route.mu.Lock()
+			route.IsReady = false
+			route.mu.Unlock()
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ready := h.Check(ctx, route.HealthCheck, "background")
+		cancel()
+
+		route.mu.Lock()
+		previous := route.IsReady
+		route.IsReady = ready
+		route.LastCheck = h.clock.Now()
+		route.mu.Unlock()
+
+		if ready != previous {
+			status := "NOT READY"
+			if ready {
+				status = "READY"
+			}
+			h.logger.Info("Route %s on machine %s: %s", route.Name, machine.Name, status)
+		}
+	}
+}
+
+// routesTo returns the routes that reach the given machine.
+func routesTo(machine *Machine, routes []*Route) []*Route {
+	matched := make([]*Route, 0, len(routes))
+	for _, route := range routes {
+		if route.Machine == machine {
+			matched = append(matched, route)
+		}
+	}
+	return matched
 }
 
 func (h *EndpointHealthChecker) markInitialCheckDone(name string) {
@@ -613,6 +662,7 @@ func (p *ProxyService) Start(ctx context.Context) error {
 	p.healthChecker.StartBackgroundChecks(
 		ctx,
 		p.config.Machines,
+		p.config.Routes,
 		p.config.HealthCheckInterval,
 	)
 
@@ -688,7 +738,7 @@ func (p *ProxyService) handleRequest(w http.ResponseWriter, r *http.Request) {
 	cached, reason := p.healthCacheStatus(machineState)
 	if cached {
 		p.logger.Info("Machine %s is healthy, proxying immediately", machineName)
-		p.proxyRequest(w, r, route)
+		p.serveWhenReady(w, r, route)
 		return
 	}
 
@@ -702,7 +752,71 @@ func (p *ProxyService) handleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	p.logger.Info("Machine %s is now healthy, proxying request", machineName)
+	p.serveWhenReady(w, r, route)
+}
+
+// serveWhenReady gates forwarding on the route's own readiness. A machine can be
+// awake seconds before the service behind a route accepts connections, and
+// forwarding into that gap turns a successful wake into a 502.
+func (p *ProxyService) serveWhenReady(w http.ResponseWriter, r *http.Request, route *Route) {
+	cached, reason := p.readyCacheStatus(route)
+	if cached {
+		p.proxyRequest(w, r, route)
+		return
+	}
+
+	p.logger.Info("Route %s not ready (%s), waiting", route.Name, reason)
+	if err := p.waitForReady(r.Context(), route); err != nil {
+		p.logger.Error("Route %s did not become ready: %v", route.Name, err)
+		http.Error(w, "Service temporarily unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
 	p.proxyRequest(w, r, route)
+}
+
+func (p *ProxyService) readyCacheStatus(route *Route) (cached bool, reason string) {
+	route.mu.RLock()
+	defer route.mu.RUnlock()
+
+	if !route.IsReady {
+		if route.LastCheck.IsZero() {
+			return false, "no prior readiness check"
+		}
+		return false, fmt.Sprintf("marked unready (last check %v ago)",
+			p.clock.Now().Sub(route.LastCheck).Round(time.Second))
+	}
+
+	age := p.clock.Now().Sub(route.LastCheck)
+	if age > p.config.HealthCacheDuration {
+		return false, fmt.Sprintf("cached readiness expired (last check %v ago)", age.Round(time.Second))
+	}
+
+	return true, ""
+}
+
+func (p *ProxyService) waitForReady(ctx context.Context, route *Route) error {
+	timeout := p.clock.After(p.config.Timeout)
+	ticker := p.clock.NewTicker(p.config.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for route %s to become ready after %v",
+				route.Name, p.config.Timeout)
+		case <-ticker.C():
+			if p.healthChecker.Check(ctx, route.HealthCheck, "readiness") {
+				route.mu.Lock()
+				route.IsReady = true
+				route.LastCheck = p.clock.Now()
+				route.mu.Unlock()
+				return nil
+			}
+		}
+	}
 }
 
 func (p *ProxyService) routeForRequest(r *http.Request) *Route {

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ type Logger interface {
 	Error(msg string, args ...interface{})
 }
 
+const tcpScheme = "tcp://"
+
 type Ticker interface {
 	C() <-chan time.Time
 	Stop()
@@ -147,6 +149,10 @@ type Route struct {
 	Hostname    string
 	ListenPort  int
 	Destination string
+	// HealthCheck is this route's readiness check: can this route serve? It is
+	// distinct from the machine's liveness check, which answers whether the box is
+	// up at all. Defaults to dialing Destination.
+	HealthCheck string
 }
 
 // IsTCP reports whether this route is reached by its own listening socket rather
@@ -186,8 +192,8 @@ type Machine struct {
 	mu           sync.RWMutex
 }
 
-// HTTP Health Checker implementation
-type HTTPHealthChecker struct {
+// Health checker: dispatches on the endpoint scheme — tcp:// dials, anything else is an HTTP GET
+type EndpointHealthChecker struct {
 	client           *http.Client
 	logger           Logger
 	clock            Clock
@@ -196,11 +202,11 @@ type HTTPHealthChecker struct {
 	initialWaitGroup sync.WaitGroup
 }
 
-func NewHTTPHealthChecker(logger Logger, clock Clock) *HTTPHealthChecker {
+func NewEndpointHealthChecker(logger Logger, clock Clock) *EndpointHealthChecker {
 	transport := &http.Transport{
 		DisableKeepAlives: true,
 	}
-	return &HTTPHealthChecker{
+	return &EndpointHealthChecker{
 		client: &http.Client{
 			Timeout:   5 * time.Second,
 			Transport: transport,
@@ -211,13 +217,34 @@ func NewHTTPHealthChecker(logger Logger, clock Clock) *HTTPHealthChecker {
 	}
 }
 
-func (h *HTTPHealthChecker) CloseIdleConnections() {
+func (h *EndpointHealthChecker) CloseIdleConnections() {
 	if transport, ok := h.client.Transport.(*http.Transport); ok {
 		transport.CloseIdleConnections()
 	}
 }
 
-func (h *HTTPHealthChecker) Check(ctx context.Context, endpoint string, source string) bool {
+func (h *EndpointHealthChecker) Check(ctx context.Context, endpoint string, source string) bool {
+	if address, ok := strings.CutPrefix(endpoint, tcpScheme); ok {
+		return h.checkTCP(ctx, address, source)
+	}
+	return h.checkHTTP(ctx, endpoint, source)
+}
+
+// checkTCP reports liveness by opening and immediately closing a connection. For
+// anything that is not an HTTP server — sshd being the motivating case — accepting
+// a connection is the only readiness signal there is.
+func (h *EndpointHealthChecker) checkTCP(ctx context.Context, address string, source string) bool {
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		h.logger.Info("Health check (%s) failed for %s%s: %v", source, tcpScheme, address, err)
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+func (h *EndpointHealthChecker) checkHTTP(ctx context.Context, endpoint string, source string) bool {
 	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		h.logger.Info("Health check (%s) failed for %s: %v", source, endpoint, err)
@@ -239,14 +266,14 @@ func (h *HTTPHealthChecker) Check(ctx context.Context, endpoint string, source s
 	return true
 }
 
-func (h *HTTPHealthChecker) StartBackgroundChecks(ctx context.Context, machines map[string]*Machine, interval time.Duration) {
+func (h *EndpointHealthChecker) StartBackgroundChecks(ctx context.Context, machines map[string]*Machine, interval time.Duration) {
 	for name, machine := range machines {
 		h.initialWaitGroup.Add(1)
 		go h.backgroundCheck(ctx, name, machine, interval)
 	}
 }
 
-func (h *HTTPHealthChecker) WaitForInitialChecks(ctx context.Context) error {
+func (h *EndpointHealthChecker) WaitForInitialChecks(ctx context.Context) error {
 	done := make(chan struct{})
 	go func() {
 		h.initialWaitGroup.Wait()
@@ -261,7 +288,7 @@ func (h *HTTPHealthChecker) WaitForInitialChecks(ctx context.Context) error {
 	}
 }
 
-func (h *HTTPHealthChecker) backgroundCheck(ctx context.Context, name string, machine *Machine, interval time.Duration) {
+func (h *EndpointHealthChecker) backgroundCheck(ctx context.Context, name string, machine *Machine, interval time.Duration) {
 	// Perform initial check
 	h.performCheck(name, machine)
 	h.markInitialCheckDone(name)
@@ -280,7 +307,7 @@ func (h *HTTPHealthChecker) backgroundCheck(ctx context.Context, name string, ma
 	}
 }
 
-func (h *HTTPHealthChecker) performCheck(name string, machine *Machine) {
+func (h *EndpointHealthChecker) performCheck(name string, machine *Machine) {
 	machine.mu.RLock()
 	isWaking := machine.IsWaking
 	machine.mu.RUnlock()
@@ -321,7 +348,7 @@ func (h *HTTPHealthChecker) performCheck(name string, machine *Machine) {
 	}
 }
 
-func (h *HTTPHealthChecker) markInitialCheckDone(name string) {
+func (h *EndpointHealthChecker) markInitialCheckDone(name string) {
 	h.initialCheckMu.Lock()
 	defer h.initialCheckMu.Unlock()
 	h.initialCheckDone[name] = true
@@ -950,6 +977,39 @@ func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 	}, nil
 }
 
+// defaultHealthCheckForDestination derives a route's readiness check from where it
+// forwards to: dialing the destination is free, since the proxy is about to connect
+// there anyway. HTTP destinations are URLs and may leave the port implicit; TCP
+// destinations are already host:port.
+func defaultHealthCheckForDestination(destination string) (string, error) {
+	if !strings.Contains(destination, "://") {
+		if _, _, err := net.SplitHostPort(destination); err != nil {
+			return "", fmt.Errorf("destination %q must be host:port or a URL: %w", destination, err)
+		}
+		return tcpScheme + destination, nil
+	}
+
+	parsed, err := url.Parse(destination)
+	if err != nil {
+		return "", fmt.Errorf("invalid destination %q: %w", destination, err)
+	}
+
+	host, port := parsed.Hostname(), parsed.Port()
+	if host == "" {
+		return "", fmt.Errorf("destination %q has no host", destination)
+	}
+	if port == "" {
+		switch parsed.Scheme {
+		case "https":
+			port = "443"
+		default:
+			port = "80"
+		}
+	}
+
+	return tcpScheme + net.JoinHostPort(host, port), nil
+}
+
 // MigrateConfigFile writes the machines + routes translation of a legacy config
 // next to the original, so an operator can adopt it with a single mv. The original
 // is never touched: it is often bind-mounted read-only or checked into a config
@@ -1030,6 +1090,9 @@ func migrateLegacyTargets(targets []Target) ([]MachineEntry, []RouteEntry) {
 			Machine:     target.Name,
 			Hostname:    target.Hostname,
 			Destination: target.Destination,
+			// A legacy health_endpoint gated both waking and forwarding, so it
+			// becomes the machine's liveness check and this route's readiness check.
+			HealthCheck: target.HealthEndpoint,
 		})
 	}
 
@@ -1119,12 +1182,21 @@ func buildMachinesAndRoutes(machineEntries []MachineEntry, routeEntries []RouteE
 			return routing{}, fmt.Errorf("route %s references undefined machine %q", name, entry.Machine)
 		}
 
+		healthCheck := entry.HealthCheck
+		if healthCheck == "" {
+			healthCheck, err = defaultHealthCheckForDestination(entry.Destination)
+			if err != nil {
+				return routing{}, fmt.Errorf("route %s: %w", name, err)
+			}
+		}
+
 		route := &Route{
 			Name:        name,
 			Machine:     machine,
 			Hostname:    entry.Hostname,
 			ListenPort:  entry.ListenPort,
 			Destination: entry.Destination,
+			HealthCheck: healthCheck,
 		}
 		routes = append(routes, route)
 		if route.IsTCP() {
@@ -1168,7 +1240,7 @@ func main() {
 	}
 
 	// Initialize dependencies
-	healthChecker := NewHTTPHealthChecker(logger, clock)
+	healthChecker := NewEndpointHealthChecker(logger, clock)
 	wolSender := NewUDPWOLSender(logger)
 	sshExecutor := NewDefaultSSHExecutor(logger)
 

--- a/main.go
+++ b/main.go
@@ -857,6 +857,13 @@ func (p *ProxyService) readyCacheStatus(route *Route) (cached bool, reason strin
 }
 
 func (p *ProxyService) waitForReady(ctx context.Context, route *Route) error {
+	// Check before waiting on a tick. A cached readiness result expires well before
+	// the next background sweep refreshes it, so most requests that land here are for
+	// routes that are in fact ready and should not pay a poll interval of latency.
+	if p.markReadyIfHealthy(ctx, route) {
+		return nil
+	}
+
 	timeout := p.clock.After(p.config.Timeout)
 	ticker := p.clock.NewTicker(p.config.PollInterval)
 	defer ticker.Stop()
@@ -869,15 +876,23 @@ func (p *ProxyService) waitForReady(ctx context.Context, route *Route) error {
 			return fmt.Errorf("timeout waiting for route %s to become ready after %v",
 				route.Name, p.config.Timeout)
 		case <-ticker.C():
-			if p.healthChecker.Check(ctx, route.HealthCheck, "readiness") {
-				route.mu.Lock()
-				route.IsReady = true
-				route.LastCheck = p.clock.Now()
-				route.mu.Unlock()
+			if p.markReadyIfHealthy(ctx, route) {
 				return nil
 			}
 		}
 	}
+}
+
+func (p *ProxyService) markReadyIfHealthy(ctx context.Context, route *Route) bool {
+	if !p.healthChecker.Check(ctx, route.HealthCheck, "readiness") {
+		return false
+	}
+
+	route.mu.Lock()
+	route.IsReady = true
+	route.LastCheck = p.clock.Now()
+	route.mu.Unlock()
+	return true
 }
 
 func (p *ProxyService) routeForRequest(r *http.Request) *Route {

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -67,41 +68,41 @@ func (r *realTicker) Stop()               { r.t.Stop() }
 type Config struct {
 	Port                  string         `toml:"port"`
 	Timeout               string         `toml:"timeout"`
-	ResponseHeaderTimeout string         `toml:"response_header_timeout"`
+	ResponseHeaderTimeout string         `toml:"response_header_timeout,omitempty"`
 	PollInterval          string         `toml:"poll_interval"`
 	HealthCheckInterval   string         `toml:"health_check_interval"`
 	HealthCacheDuration   string         `toml:"health_cache_duration"`
-	SSLCertificate        string         `toml:"ssl_certificate"`
-	SSLCertificateKey     string         `toml:"ssl_certificate_key"`
-	Targets               []Target       `toml:"targets"` // legacy, superseded by machines + routes
-	Machines              []MachineEntry `toml:"machines"`
-	Routes                []RouteEntry   `toml:"routes"`
+	SSLCertificate        string         `toml:"ssl_certificate,omitempty"`
+	SSLCertificateKey     string         `toml:"ssl_certificate_key,omitempty"`
+	Targets               []Target       `toml:"targets,omitempty"` // legacy, superseded by machines + routes
+	Machines              []MachineEntry `toml:"machines,omitempty"`
+	Routes                []RouteEntry   `toml:"routes,omitempty"`
 }
 
 // MachineEntry is a [[machines]] block as written in the config file.
 type MachineEntry struct {
 	Name                 string `toml:"name"`
-	MacAddress           string `toml:"mac_address"`
-	BroadcastIP          string `toml:"broadcast_ip"`
-	WolPort              int    `toml:"wol_port"`
-	HealthCheck          string `toml:"health_check"`
-	SSHHost              string `toml:"ssh_host"`
-	SSHUser              string `toml:"ssh_user"`
-	SSHKeyPath           string `toml:"ssh_key_path"`
-	ShutdownCommand      string `toml:"shutdown_command"`
-	ShutdownHTTPUrl      string `toml:"shutdown_http_url"`
-	ShutdownHTTPMethod   string `toml:"shutdown_http_method"`
-	ShutdownHTTPOKStatus int    `toml:"shutdown_http_ok_status"`
-	InactivityThreshold  string `toml:"inactivity_threshold"`
+	MacAddress           string `toml:"mac_address,omitempty"`
+	BroadcastIP          string `toml:"broadcast_ip,omitempty"`
+	WolPort              int    `toml:"wol_port,omitempty"`
+	HealthCheck          string `toml:"health_check,omitempty"`
+	SSHHost              string `toml:"ssh_host,omitempty"`
+	SSHUser              string `toml:"ssh_user,omitempty"`
+	SSHKeyPath           string `toml:"ssh_key_path,omitempty"`
+	ShutdownCommand      string `toml:"shutdown_command,omitempty"`
+	ShutdownHTTPUrl      string `toml:"shutdown_http_url,omitempty"`
+	ShutdownHTTPMethod   string `toml:"shutdown_http_method,omitempty"`
+	ShutdownHTTPOKStatus int    `toml:"shutdown_http_ok_status,omitempty"`
+	InactivityThreshold  string `toml:"inactivity_threshold,omitempty"`
 }
 
 // RouteEntry is a [[routes]] block as written in the config file.
 type RouteEntry struct {
 	Machine     string `toml:"machine"`
-	Hostname    string `toml:"hostname"`
-	ListenPort  int    `toml:"listen_port"`
-	Destination string `toml:"destination"`
-	HealthCheck string `toml:"health_check"`
+	Hostname    string `toml:"hostname,omitempty"`
+	ListenPort  int    `toml:"listen_port,omitempty"`
+	Destination string `toml:"destination,omitempty"`
+	HealthCheck string `toml:"health_check,omitempty"`
 }
 
 type Target struct {
@@ -923,12 +924,12 @@ func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 		return nil, fmt.Errorf("config mixes the legacy [[targets]] format with [[machines]]/[[routes]]; use one or the other")
 	}
 
-	var model routing
+	machineEntries, routeEntries := config.Machines, config.Routes
 	if len(config.Targets) > 0 {
-		model, err = buildFromLegacyTargets(config.Targets, clock)
-	} else {
-		model, err = buildMachinesAndRoutes(config.Machines, config.Routes, clock)
+		machineEntries, routeEntries = migrateLegacyTargets(config.Targets)
 	}
+
+	model, err := buildMachinesAndRoutes(machineEntries, routeEntries, clock)
 	if err != nil {
 		return nil, err
 	}
@@ -949,75 +950,90 @@ func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 	}, nil
 }
 
-// buildFromLegacyTargets desugars each [[targets]] block into one machine plus one
-// route pointing at it.
-func buildFromLegacyTargets(targets []Target, clock Clock) (routing, error) {
-	machines := make(map[string]*Machine)
-	routes := make([]*Route, 0, len(targets))
-	routesByHostname := make(map[string]*Route)
-	var err error
-
-	for _, target := range targets {
-		if target.Hostname == "" {
-			return routing{}, fmt.Errorf("target %s is missing hostname", target.Name)
-		}
-
-		// Check for duplicate hostnames
-		if existing, exists := routesByHostname[target.Hostname]; exists {
-			return routing{}, fmt.Errorf("duplicate hostname %s for targets %s and %s",
-				target.Hostname, existing.Name, target.Name)
-		}
-
-		// Validate shutdown configuration
-		// Disallow using both SSH shutdown command and HTTP shutdown URL
-		if strings.TrimSpace(target.ShutdownHTTPUrl) != "" && strings.TrimSpace(target.ShutdownCommand) != "" {
-			return routing{}, fmt.Errorf("target %s: cannot define both shutdown_http_url and shutdown_command; choose one", target.Name)
-		}
-
-		// Disallow http method/ok status without URL
-		if strings.TrimSpace(target.ShutdownHTTPUrl) == "" && (strings.TrimSpace(target.ShutdownHTTPMethod) != "" || target.ShutdownHTTPOKStatus != 0) {
-			return routing{}, fmt.Errorf("target %s: shutdown_http_method and/or shutdown_http_ok_status require shutdown_http_url to be set", target.Name)
-		}
-
-		var inactivityThreshold time.Duration
-		if target.InactivityThreshold != "" {
-			inactivityThreshold, err = time.ParseDuration(target.InactivityThreshold)
-			if err != nil {
-				return routing{}, fmt.Errorf("invalid inactivity_threshold for target %s: %w", target.Name, err)
-			}
-		}
-
-		machineState := &Machine{
-			Name: target.Name,
-			Config: &MachineConfig{
-				MacAddress:           target.MacAddress,
-				BroadcastIP:          target.BroadcastIP,
-				WolPort:              target.WolPort,
-				HealthCheck:          target.HealthEndpoint,
-				SSHHost:              target.SSHHost,
-				SSHUser:              target.SSHUser,
-				SSHKeyPath:           target.SSHKeyPath,
-				ShutdownCommand:      target.ShutdownCommand,
-				ShutdownHTTPUrl:      target.ShutdownHTTPUrl,
-				ShutdownHTTPMethod:   target.ShutdownHTTPMethod,
-				ShutdownHTTPOKStatus: target.ShutdownHTTPOKStatus,
-				InactivityThreshold:  inactivityThreshold,
-			},
-			LastActivity: clock.Now(),
-		}
-		machines[target.Name] = machineState
-
-		route := &Route{
-			Name:        target.Name,
-			Machine:     machineState,
-			Hostname:    target.Hostname,
-			Destination: target.Destination,
-		}
-		routes = append(routes, route)
-		routesByHostname[target.Hostname] = route
+// MigrateConfigFile writes the machines + routes translation of a legacy config
+// next to the original, so an operator can adopt it with a single mv. The original
+// is never touched: it is often bind-mounted read-only or checked into a config
+// repo, and rewriting it would silently drop every comment. If the sidecar cannot
+// be written, the translation is logged instead so nothing is lost.
+func MigrateConfigFile(path string, logger Logger) {
+	var config Config
+	if _, err := toml.DecodeFile(path, &config); err != nil {
+		return
+	}
+	if len(config.Targets) == 0 {
+		return
 	}
 
-	return routing{machines: machines, routes: routes, byHostname: routesByHostname, byListenPort: map[int]*Route{}}, nil
+	config.Machines, config.Routes = migrateLegacyTargets(config.Targets)
+	config.Targets = nil
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(config); err != nil {
+		logger.Error("Could not translate the legacy config: %v", err)
+		return
+	}
+	migrated := dropUnsetIntKeys(buf.String())
+
+	ext := filepath.Ext(path)
+	migratedPath := strings.TrimSuffix(path, ext) + ".migrated" + ext
+
+	if err := os.WriteFile(migratedPath, []byte(migrated), 0o600); err != nil {
+		logger.Info("This config uses the legacy [[targets]] format. Could not write %s (%v); "+
+			"the migrated config follows — save it yourself:\n%s", migratedPath, err, migrated)
+		return
+	}
+
+	logger.Info("This config uses the legacy [[targets]] format, which will be removed in a future "+
+		"release. A migrated copy was written to %s — review it and replace your config with it.", migratedPath)
+}
+
+// dropUnsetIntKeys removes "key = 0" lines from encoded TOML. The toml encoder
+// honours omitempty for strings but not for ints, and every int key in this config
+// means "unset" at zero — emitting them would litter a migrated config with keys
+// the operator never wrote.
+func dropUnsetIntKeys(encoded string) string {
+	lines := strings.Split(encoded, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasSuffix(strings.TrimSpace(line), "= 0") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
+// migrateLegacyTargets translates [[targets]] blocks into the machines + routes
+// form. Each legacy target was a machine and a route rolled into one, so it
+// becomes exactly one of each.
+func migrateLegacyTargets(targets []Target) ([]MachineEntry, []RouteEntry) {
+	machines := make([]MachineEntry, 0, len(targets))
+	routes := make([]RouteEntry, 0, len(targets))
+
+	for _, target := range targets {
+		machines = append(machines, MachineEntry{
+			Name:                 target.Name,
+			MacAddress:           target.MacAddress,
+			BroadcastIP:          target.BroadcastIP,
+			WolPort:              target.WolPort,
+			HealthCheck:          target.HealthEndpoint,
+			SSHHost:              target.SSHHost,
+			SSHUser:              target.SSHUser,
+			SSHKeyPath:           target.SSHKeyPath,
+			ShutdownCommand:      target.ShutdownCommand,
+			ShutdownHTTPUrl:      target.ShutdownHTTPUrl,
+			ShutdownHTTPMethod:   target.ShutdownHTTPMethod,
+			ShutdownHTTPOKStatus: target.ShutdownHTTPOKStatus,
+			InactivityThreshold:  target.InactivityThreshold,
+		})
+		routes = append(routes, RouteEntry{
+			Machine:     target.Name,
+			Hostname:    target.Hostname,
+			Destination: target.Destination,
+		})
+	}
+
+	return machines, routes
 }
 
 // buildMachinesAndRoutes turns the machine and route blocks of a config file into
@@ -1036,6 +1052,16 @@ func buildMachinesAndRoutes(machineEntries []MachineEntry, routeEntries []RouteE
 		}
 		if _, exists := machines[entry.Name]; exists {
 			return routing{}, fmt.Errorf("duplicate machine name %q", entry.Name)
+		}
+
+		// Disallow using both SSH shutdown command and HTTP shutdown URL
+		if strings.TrimSpace(entry.ShutdownHTTPUrl) != "" && strings.TrimSpace(entry.ShutdownCommand) != "" {
+			return routing{}, fmt.Errorf("machine %s: cannot define both shutdown_http_url and shutdown_command; choose one", entry.Name)
+		}
+
+		// Disallow http method/ok status without URL
+		if strings.TrimSpace(entry.ShutdownHTTPUrl) == "" && (strings.TrimSpace(entry.ShutdownHTTPMethod) != "" || entry.ShutdownHTTPOKStatus != 0) {
+			return routing{}, fmt.Errorf("machine %s: shutdown_http_method and/or shutdown_http_ok_status require shutdown_http_url to be set", entry.Name)
 		}
 
 		var inactivityThreshold time.Duration
@@ -1132,6 +1158,9 @@ func main() {
 
 	// Load configuration
 	clock := RealClock{}
+	logger := &StdLogger{}
+
+	MigrateConfigFile(configFile, logger)
 
 	config, err := LoadConfig(configFile, clock)
 	if err != nil {
@@ -1139,7 +1168,6 @@ func main() {
 	}
 
 	// Initialize dependencies
-	logger := &StdLogger{}
 	healthChecker := NewHTTPHealthChecker(logger, clock)
 	wolSender := NewUDPWOLSender(logger)
 	sshExecutor := NewDefaultSSHExecutor(logger)

--- a/main.go
+++ b/main.go
@@ -1313,9 +1313,20 @@ func (p *ProxyService) proxyRequest(w http.ResponseWriter, r *http.Request, rout
 // Config loader
 func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 	var config Config
-	_, err := toml.DecodeFile(filename, &config)
+	meta, err := toml.DecodeFile(filename, &config)
 	if err != nil {
 		return nil, err
+	}
+
+	// A key the struct does not claim is almost always a typo, and decoding leaves
+	// the field at its zero value — which is how a config ends up with, say, no
+	// health check at all and no hint as to why. Refuse rather than run degraded.
+	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+		keys := make([]string, 0, len(undecoded))
+		for _, key := range undecoded {
+			keys = append(keys, key.String())
+		}
+		return nil, fmt.Errorf("unknown key(s) in %s: %s", filename, strings.Join(keys, ", "))
 	}
 
 	// Trim whitespace and handle optional SSL certificate fields
@@ -1363,11 +1374,12 @@ func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 	}
 
 	machineEntries, routeEntries := config.Machines, config.Routes
-	if len(config.Targets) > 0 {
+	fromLegacy := len(config.Targets) > 0
+	if fromLegacy {
 		machineEntries, routeEntries = migrateLegacyTargets(config.Targets)
 	}
 
-	model, err := buildMachinesAndRoutes(machineEntries, routeEntries, clock)
+	model, err := buildMachinesAndRoutes(machineEntries, routeEntries, clock, fromLegacy)
 	if err != nil {
 		return nil, err
 	}
@@ -1513,7 +1525,40 @@ func migrateLegacyTargets(targets []Target) ([]MachineEntry, []RouteEntry) {
 // buildMachinesAndRoutes turns the machine and route blocks of a config file into
 // the runtime model: one Machine per machine block, shared by every route that
 // names it.
-func buildMachinesAndRoutes(machineEntries []MachineEntry, routeEntries []RouteEntry, clock Clock) (routing, error) {
+// validateDestination rejects a destination that cannot work for its route kind, at
+// load time rather than on the first connection. A TCP route dials the string
+// directly, so it must be host:port. An HTTP route builds a reverse proxy from it,
+// and url.Parse accepts far too much: "nas.local:2342" parses as scheme "nas.local"
+// with opaque body "2342" — dots are legal in scheme names — yielding a proxy that
+// 502s every request with nothing in the logs to explain it.
+func validateDestination(name, destination string, isTCP bool) error {
+	if strings.TrimSpace(destination) == "" {
+		return fmt.Errorf("route %s needs a destination", name)
+	}
+
+	if isTCP {
+		if _, _, err := net.SplitHostPort(destination); err != nil {
+			return fmt.Errorf("route %s forwards raw TCP, so destination %q must be host:port: %w",
+				name, destination, err)
+		}
+		return nil
+	}
+
+	parsed, err := url.Parse(destination)
+	if err != nil {
+		return fmt.Errorf("route %s: invalid destination %q: %w", name, destination, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("route %s proxies HTTP, so destination %q must be an http:// or https:// URL",
+			name, destination)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("route %s: destination %q has no host", name, destination)
+	}
+	return nil
+}
+
+func buildMachinesAndRoutes(machineEntries []MachineEntry, routeEntries []RouteEntry, clock Clock, fromLegacy bool) (routing, error) {
 	machines := make(map[string]*Machine)
 	routes := make([]*Route, 0, len(routeEntries))
 	routesByHostname := make(map[string]*Route)
@@ -1526,6 +1571,20 @@ func buildMachinesAndRoutes(machineEntries []MachineEntry, routeEntries []RouteE
 		}
 		if _, exists := machines[entry.Name]; exists {
 			return routing{}, fmt.Errorf("duplicate machine name %q", entry.Name)
+		}
+
+		// Liveness drives waking, the wake wait and the shutdown decision. Without it
+		// every Check fails, the machine is permanently unhealthy, and every request
+		// sprays WOL for the whole timeout before returning 503. Name the key the
+		// operator actually wrote, which differs in the legacy format.
+		if strings.TrimSpace(entry.HealthCheck) == "" {
+			key := "health_check"
+			if fromLegacy {
+				key = "health_endpoint"
+			}
+			return routing{}, fmt.Errorf(
+				"machine %s needs a %s: it is how the proxy tells whether the box is up",
+				entry.Name, key)
 		}
 
 		// Disallow using both SSH shutdown command and HTTP shutdown URL
@@ -1591,6 +1650,13 @@ func buildMachinesAndRoutes(machineEntries []MachineEntry, routeEntries []RouteE
 		machine, exists := machines[entry.Machine]
 		if !exists {
 			return routing{}, fmt.Errorf("route %s references undefined machine %q", name, entry.Machine)
+		}
+
+		// Validate regardless of whether health_check was given: deriving the check
+		// from the destination used to be the only thing that looked at it, so an
+		// explicit health_check silently bought a pass on a broken destination.
+		if err := validateDestination(name, entry.Destination, entry.ListenPort != 0); err != nil {
+			return routing{}, err
 		}
 
 		healthCheck := entry.HealthCheck

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,9 +14,11 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -44,6 +47,9 @@ type Logger interface {
 }
 
 const tcpScheme = "tcp://"
+
+// shutdownGrace is how long in-flight requests get to finish on shutdown.
+const shutdownGrace = 15 * time.Second
 
 type Ticker interface {
 	C() <-chan time.Time
@@ -747,17 +753,37 @@ func (p *ProxyService) Start(ctx context.Context) error {
 		MaxHeaderBytes:    1 << 20,
 	}
 
-	go func() { errs <- p.serveHTTP(ctx, server) }()
+	httpListener, err := net.Listen("tcp", p.config.Port)
+	if err != nil {
+		return fmt.Errorf("could not listen on %s: %w", p.config.Port, err)
+	}
+
+	go func() { errs <- p.serveHTTP(ctx, server, httpListener) }()
 
 	return <-errs
 }
 
-func (p *ProxyService) serveHTTP(ctx context.Context, server *http.Server) error {
+// serveHTTP serves until the context is cancelled, then drains in-flight requests
+// before returning. A clean shutdown is not an error.
+func (p *ProxyService) serveHTTP(ctx context.Context, server *http.Server, listener net.Listener) error {
 	go func() {
 		<-ctx.Done()
-		server.Close()
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			server.Close()
+		}
 	}()
 
+	err := p.serveOn(server, listener)
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+func (p *ProxyService) serveOn(server *http.Server, listener net.Listener) error {
 	if isSecureServer(p.config) {
 		// Use HTTPS when both certificate and key are provided
 		tlsConfig := &tls.Config{
@@ -771,12 +797,12 @@ func (p *ProxyService) serveHTTP(ctx context.Context, server *http.Server) error
 		tlsConfig.Certificates[0] = cert
 		server.TLSConfig = tlsConfig
 
-		p.logger.Info("HTTPS server listening on %s with SSL certificates", p.config.Port)
+		p.logger.Info("HTTPS server listening on %s with SSL certificates", listener.Addr())
 		//The files in these methods are ignored since there is already a certificate in the config.
-		return server.ListenAndServeTLS("", "")
+		return server.ServeTLS(listener, "", "")
 	} else {
-		p.logger.Info("HTTP server listening on %s", p.config.Port)
-		return server.ListenAndServe()
+		p.logger.Info("HTTP server listening on %s", listener.Addr())
+		return server.Serve(listener)
 	}
 }
 
@@ -1533,9 +1559,13 @@ func main() {
 	// Create proxy service
 	proxy := NewProxyService(config, healthChecker, wolSender, sshExecutor, logger, clock)
 
-	// Start the service
-	ctx := context.Background()
+	// Start the service, shutting down cleanly on SIGINT/SIGTERM
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	if err := proxy.Start(ctx); err != nil {
 		log.Fatalf("Failed to start proxy: %v", err)
 	}
+
+	logger.Info("Shut down cleanly")
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -680,7 +681,27 @@ func (p *ProxyService) Start(ctx context.Context) error {
 	// Log configured routes
 	for _, route := range p.config.Routes {
 		p.logger.Info("Configured route: %s -> %s (%s)",
-			route.Hostname, route.Machine.Name, route.Destination)
+			route.Name, route.Machine.Name, route.Destination)
+	}
+
+	// Bind every TCP route before serving anything, so a port clash is reported at
+	// startup rather than leaving the proxy half up.
+	errs := make(chan error, len(p.config.Routes)+1)
+	for _, route := range p.config.Routes {
+		if !route.IsTCP() {
+			continue
+		}
+
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", route.ListenPort))
+		if err != nil {
+			return fmt.Errorf("could not listen on port %d for machine %s: %w",
+				route.ListenPort, route.Machine.Name, err)
+		}
+		defer listener.Close()
+
+		go func(listener net.Listener, route *Route) {
+			errs <- p.serveTCPRoute(ctx, listener, route)
+		}(listener, route)
 	}
 
 	// Start HTTP/HTTPS server
@@ -696,6 +717,17 @@ func (p *ProxyService) Start(ctx context.Context) error {
 		ReadHeaderTimeout: 30 * time.Second,
 		MaxHeaderBytes:    1 << 20,
 	}
+
+	go func() { errs <- p.serveHTTP(ctx, server) }()
+
+	return <-errs
+}
+
+func (p *ProxyService) serveHTTP(ctx context.Context, server *http.Server) error {
+	go func() {
+		<-ctx.Done()
+		server.Close()
+	}()
 
 	if isSecureServer(p.config) {
 		// Use HTTPS when both certificate and key are provided
@@ -938,6 +970,75 @@ func (p *ProxyService) waitForWake(ctx context.Context, machine *Machine) error 
 				return nil
 			}
 		}
+	}
+}
+
+// serveTCPRoute accepts connections on listener and forwards each to the route's
+// destination, waking the machine first if it is asleep. It returns when ctx is
+// cancelled or the listener stops accepting.
+func (p *ProxyService) serveTCPRoute(ctx context.Context, listener net.Listener, route *Route) error {
+	go func() {
+		<-ctx.Done()
+		listener.Close()
+	}()
+
+	p.logger.Info("Listening on %s for machine %s -> %s",
+		listener.Addr(), route.Machine.Name, route.Destination)
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("accept on %s failed: %w", listener.Addr(), err)
+		}
+		go p.forwardTCPConn(ctx, conn, route)
+	}
+}
+
+// forwardTCPConn wakes the machine if needed, then splices the accepted connection
+// to the destination. The client is already connected while we wake, so it waits on
+// the upstream's protocol banner rather than on connect — an ssh client with a short
+// ConnectTimeout still gets through a slow wake.
+func (p *ProxyService) forwardTCPConn(ctx context.Context, client net.Conn, route *Route) {
+	defer client.Close()
+
+	machine := route.Machine
+	if cached, reason := p.healthCacheStatus(machine); !cached {
+		p.logger.Info("Machine %s appears down (%s), waking for %s", machine.Name, reason, route.Name)
+		if err := p.wakeAndWait(ctx, machine); err != nil {
+			p.logger.Error("Failed to wake machine %s for %s: %v", machine.Name, route.Name, err)
+			return
+		}
+	}
+
+	upstream, err := net.Dial("tcp", route.Destination)
+	if err != nil {
+		p.logger.Error("Could not reach %s for route %s: %v", route.Destination, route.Name, err)
+		return
+	}
+	defer upstream.Close()
+
+	machine.mu.Lock()
+	machine.LastActivity = p.clock.Now()
+	machine.mu.Unlock()
+
+	done := make(chan struct{}, 2)
+	splice := func(dst, src net.Conn) {
+		io.Copy(dst, src)
+		// Let the other direction drain rather than tearing the pair down mid-write.
+		if conn, ok := dst.(*net.TCPConn); ok {
+			conn.CloseWrite()
+		}
+		done <- struct{}{}
+	}
+	go splice(upstream, client)
+	go splice(client, upstream)
+
+	select {
+	case <-done:
+	case <-ctx.Done():
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -194,7 +194,31 @@ type Machine struct {
 	LastCheck    time.Time
 	IsWaking     bool
 	LastActivity time.Time
+	openConns    int
 	mu           sync.RWMutex
+}
+
+// openConnections reports how many forwarded connections are currently open. A
+// long-lived idle connection — an ssh session is the motivating case — moves no
+// bytes, so LastActivity alone cannot tell the machine is still in use.
+func (m *Machine) openConnections() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.openConns
+}
+
+func (m *Machine) holdConnection() {
+	m.mu.Lock()
+	m.openConns++
+	m.mu.Unlock()
+}
+
+func (m *Machine) releaseConnection() {
+	m.mu.Lock()
+	if m.openConns > 0 {
+		m.openConns--
+	}
+	m.mu.Unlock()
 }
 
 // Health checker: dispatches on the endpoint scheme — tcp:// dials, anything else is an HTTP GET
@@ -635,9 +659,14 @@ func (p *ProxyService) checkInactiveMachines() {
 		machineState.mu.RLock()
 		isHealthy := machineState.IsHealthy
 		lastActivity := machineState.LastActivity
+		openConns := machineState.openConns
 		machineState.mu.RUnlock()
 
 		if !isHealthy {
+			continue
+		}
+
+		if openConns > 0 {
 			continue
 		}
 
@@ -1024,6 +1053,9 @@ func (p *ProxyService) forwardTCPConn(ctx context.Context, client net.Conn, rout
 	machine.LastActivity = p.clock.Now()
 	machine.mu.Unlock()
 
+	machine.holdConnection()
+	defer machine.releaseConnection()
+
 	done := make(chan struct{}, 2)
 	splice := func(dst, src net.Conn) {
 		io.Copy(dst, src)
@@ -1047,6 +1079,11 @@ func (p *ProxyService) proxyRequest(w http.ResponseWriter, r *http.Request, rout
 	machineState.mu.Lock()
 	machineState.LastActivity = p.clock.Now()
 	machineState.mu.Unlock()
+
+	// A slow upload or download can outlast the inactivity threshold; hold the
+	// machine for as long as the request is in flight.
+	machineState.holdConnection()
+	defer machineState.releaseConnection()
 
 	targetURL, err := url.Parse(route.Destination)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -65,15 +65,43 @@ func (r *realTicker) Stop()               { r.t.Stop() }
 
 // Config structs
 type Config struct {
-	Port                  string   `toml:"port"`
-	Timeout               string   `toml:"timeout"`
-	ResponseHeaderTimeout string   `toml:"response_header_timeout"`
-	PollInterval          string   `toml:"poll_interval"`
-	HealthCheckInterval   string   `toml:"health_check_interval"`
-	HealthCacheDuration   string   `toml:"health_cache_duration"`
-	SSLCertificate        string   `toml:"ssl_certificate"`
-	SSLCertificateKey     string   `toml:"ssl_certificate_key"`
-	Targets               []Target `toml:"targets"`
+	Port                  string         `toml:"port"`
+	Timeout               string         `toml:"timeout"`
+	ResponseHeaderTimeout string         `toml:"response_header_timeout"`
+	PollInterval          string         `toml:"poll_interval"`
+	HealthCheckInterval   string         `toml:"health_check_interval"`
+	HealthCacheDuration   string         `toml:"health_cache_duration"`
+	SSLCertificate        string         `toml:"ssl_certificate"`
+	SSLCertificateKey     string         `toml:"ssl_certificate_key"`
+	Targets               []Target       `toml:"targets"` // legacy, superseded by machines + routes
+	Machines              []MachineEntry `toml:"machines"`
+	Routes                []RouteEntry   `toml:"routes"`
+}
+
+// MachineEntry is a [[machines]] block as written in the config file.
+type MachineEntry struct {
+	Name                 string `toml:"name"`
+	MacAddress           string `toml:"mac_address"`
+	BroadcastIP          string `toml:"broadcast_ip"`
+	WolPort              int    `toml:"wol_port"`
+	HealthCheck          string `toml:"health_check"`
+	SSHHost              string `toml:"ssh_host"`
+	SSHUser              string `toml:"ssh_user"`
+	SSHKeyPath           string `toml:"ssh_key_path"`
+	ShutdownCommand      string `toml:"shutdown_command"`
+	ShutdownHTTPUrl      string `toml:"shutdown_http_url"`
+	ShutdownHTTPMethod   string `toml:"shutdown_http_method"`
+	ShutdownHTTPOKStatus int    `toml:"shutdown_http_ok_status"`
+	InactivityThreshold  string `toml:"inactivity_threshold"`
+}
+
+// RouteEntry is a [[routes]] block as written in the config file.
+type RouteEntry struct {
+	Machine     string `toml:"machine"`
+	Hostname    string `toml:"hostname"`
+	ListenPort  int    `toml:"listen_port"`
+	Destination string `toml:"destination"`
+	HealthCheck string `toml:"health_check"`
 }
 
 type Target struct {
@@ -116,7 +144,20 @@ type Route struct {
 	Name        string
 	Machine     *Machine
 	Hostname    string
+	ListenPort  int
 	Destination string
+}
+
+// IsTCP reports whether this route is reached by its own listening socket rather
+// than by Host header. A route has a hostname or a listen port, never both.
+func (r *Route) IsTCP() bool { return r.ListenPort != 0 }
+
+// routing is the runtime routing model: machines and the routes that reach them.
+type routing struct {
+	machines     map[string]*Machine
+	routes       []*Route
+	byHostname   map[string]*Route
+	byListenPort map[int]*Route
 }
 
 type ProxyConfig struct {
@@ -129,6 +170,7 @@ type ProxyConfig struct {
 	Machines              map[string]*Machine
 	Routes                []*Route
 	RoutesByHostname      map[string]*Route
+	RoutesByListenPort    map[int]*Route
 	SSLCertificate        string
 	SSLCertificateKey     string
 }
@@ -877,37 +919,71 @@ func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 		return nil, fmt.Errorf("invalid health_cache_duration: %w", err)
 	}
 
-	machines := make(map[string]*Machine)
-	routes := make([]*Route, 0, len(config.Targets))
-	routesByHostname := make(map[string]*Route)
+	if len(config.Targets) > 0 && (len(config.Machines) > 0 || len(config.Routes) > 0) {
+		return nil, fmt.Errorf("config mixes the legacy [[targets]] format with [[machines]]/[[routes]]; use one or the other")
+	}
 
-	for _, target := range config.Targets {
+	var model routing
+	if len(config.Targets) > 0 {
+		model, err = buildFromLegacyTargets(config.Targets, clock)
+	} else {
+		model, err = buildMachinesAndRoutes(config.Machines, config.Routes, clock)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProxyConfig{
+		Port:                  config.Port,
+		SSLCertificate:        config.SSLCertificate,
+		SSLCertificateKey:     config.SSLCertificateKey,
+		Timeout:               timeout,
+		ResponseHeaderTimeout: responseHeaderTimeout,
+		PollInterval:          pollInterval,
+		HealthCheckInterval:   healthCheckInterval,
+		HealthCacheDuration:   healthCacheDuration,
+		Machines:              model.machines,
+		Routes:                model.routes,
+		RoutesByHostname:      model.byHostname,
+		RoutesByListenPort:    model.byListenPort,
+	}, nil
+}
+
+// buildFromLegacyTargets desugars each [[targets]] block into one machine plus one
+// route pointing at it.
+func buildFromLegacyTargets(targets []Target, clock Clock) (routing, error) {
+	machines := make(map[string]*Machine)
+	routes := make([]*Route, 0, len(targets))
+	routesByHostname := make(map[string]*Route)
+	var err error
+
+	for _, target := range targets {
 		if target.Hostname == "" {
-			return nil, fmt.Errorf("target %s is missing hostname", target.Name)
+			return routing{}, fmt.Errorf("target %s is missing hostname", target.Name)
 		}
 
 		// Check for duplicate hostnames
 		if existing, exists := routesByHostname[target.Hostname]; exists {
-			return nil, fmt.Errorf("duplicate hostname %s for targets %s and %s",
+			return routing{}, fmt.Errorf("duplicate hostname %s for targets %s and %s",
 				target.Hostname, existing.Name, target.Name)
 		}
 
 		// Validate shutdown configuration
 		// Disallow using both SSH shutdown command and HTTP shutdown URL
 		if strings.TrimSpace(target.ShutdownHTTPUrl) != "" && strings.TrimSpace(target.ShutdownCommand) != "" {
-			return nil, fmt.Errorf("target %s: cannot define both shutdown_http_url and shutdown_command; choose one", target.Name)
+			return routing{}, fmt.Errorf("target %s: cannot define both shutdown_http_url and shutdown_command; choose one", target.Name)
 		}
 
 		// Disallow http method/ok status without URL
 		if strings.TrimSpace(target.ShutdownHTTPUrl) == "" && (strings.TrimSpace(target.ShutdownHTTPMethod) != "" || target.ShutdownHTTPOKStatus != 0) {
-			return nil, fmt.Errorf("target %s: shutdown_http_method and/or shutdown_http_ok_status require shutdown_http_url to be set", target.Name)
+			return routing{}, fmt.Errorf("target %s: shutdown_http_method and/or shutdown_http_ok_status require shutdown_http_url to be set", target.Name)
 		}
 
 		var inactivityThreshold time.Duration
 		if target.InactivityThreshold != "" {
 			inactivityThreshold, err = time.ParseDuration(target.InactivityThreshold)
 			if err != nil {
-				return nil, fmt.Errorf("invalid inactivity_threshold for target %s: %w", target.Name, err)
+				return routing{}, fmt.Errorf("invalid inactivity_threshold for target %s: %w", target.Name, err)
 			}
 		}
 
@@ -941,19 +1017,98 @@ func LoadConfig(filename string, clock Clock) (*ProxyConfig, error) {
 		routesByHostname[target.Hostname] = route
 	}
 
-	return &ProxyConfig{
-		Port:                  config.Port,
-		SSLCertificate:        config.SSLCertificate,
-		SSLCertificateKey:     config.SSLCertificateKey,
-		Timeout:               timeout,
-		ResponseHeaderTimeout: responseHeaderTimeout,
-		PollInterval:          pollInterval,
-		HealthCheckInterval:   healthCheckInterval,
-		HealthCacheDuration:   healthCacheDuration,
-		Machines:              machines,
-		Routes:                routes,
-		RoutesByHostname:      routesByHostname,
-	}, nil
+	return routing{machines: machines, routes: routes, byHostname: routesByHostname, byListenPort: map[int]*Route{}}, nil
+}
+
+// buildMachinesAndRoutes turns the machine and route blocks of a config file into
+// the runtime model: one Machine per machine block, shared by every route that
+// names it.
+func buildMachinesAndRoutes(machineEntries []MachineEntry, routeEntries []RouteEntry, clock Clock) (routing, error) {
+	machines := make(map[string]*Machine)
+	routes := make([]*Route, 0, len(routeEntries))
+	routesByHostname := make(map[string]*Route)
+	routesByListenPort := make(map[int]*Route)
+	var err error
+
+	for _, entry := range machineEntries {
+		if entry.Name == "" {
+			return routing{}, fmt.Errorf("every machine needs a name")
+		}
+		if _, exists := machines[entry.Name]; exists {
+			return routing{}, fmt.Errorf("duplicate machine name %q", entry.Name)
+		}
+
+		var inactivityThreshold time.Duration
+		if entry.InactivityThreshold != "" {
+			inactivityThreshold, err = time.ParseDuration(entry.InactivityThreshold)
+			if err != nil {
+				return routing{}, fmt.Errorf("invalid inactivity_threshold for machine %s: %w", entry.Name, err)
+			}
+		}
+
+		machines[entry.Name] = &Machine{
+			Name: entry.Name,
+			Config: &MachineConfig{
+				MacAddress:           entry.MacAddress,
+				BroadcastIP:          entry.BroadcastIP,
+				WolPort:              entry.WolPort,
+				HealthCheck:          entry.HealthCheck,
+				SSHHost:              entry.SSHHost,
+				SSHUser:              entry.SSHUser,
+				SSHKeyPath:           entry.SSHKeyPath,
+				ShutdownCommand:      entry.ShutdownCommand,
+				ShutdownHTTPUrl:      entry.ShutdownHTTPUrl,
+				ShutdownHTTPMethod:   entry.ShutdownHTTPMethod,
+				ShutdownHTTPOKStatus: entry.ShutdownHTTPOKStatus,
+				InactivityThreshold:  inactivityThreshold,
+			},
+			LastActivity: clock.Now(),
+		}
+	}
+
+	for _, entry := range routeEntries {
+		name := entry.Hostname
+		if name == "" {
+			name = fmt.Sprintf(":%d", entry.ListenPort)
+		}
+
+		switch {
+		case entry.Hostname == "" && entry.ListenPort == 0:
+			return routing{}, fmt.Errorf("route for machine %q needs either a hostname or a listen_port", entry.Machine)
+		case entry.Hostname != "" && entry.ListenPort != 0:
+			return routing{}, fmt.Errorf("route %s sets both hostname and listen_port; a route is reached one way or the other", name)
+		}
+
+		if existing, exists := routesByHostname[entry.Hostname]; exists {
+			return routing{}, fmt.Errorf("duplicate hostname %s for routes to machines %s and %s",
+				entry.Hostname, existing.Machine.Name, entry.Machine)
+		}
+		if existing, exists := routesByListenPort[entry.ListenPort]; exists {
+			return routing{}, fmt.Errorf("duplicate listen_port %d for routes to machines %s and %s",
+				entry.ListenPort, existing.Machine.Name, entry.Machine)
+		}
+
+		machine, exists := machines[entry.Machine]
+		if !exists {
+			return routing{}, fmt.Errorf("route %s references undefined machine %q", name, entry.Machine)
+		}
+
+		route := &Route{
+			Name:        name,
+			Machine:     machine,
+			Hostname:    entry.Hostname,
+			ListenPort:  entry.ListenPort,
+			Destination: entry.Destination,
+		}
+		routes = append(routes, route)
+		if route.IsTCP() {
+			routesByListenPort[route.ListenPort] = route
+		} else {
+			routesByHostname[route.Hostname] = route
+		}
+	}
+
+	return routing{machines: machines, routes: routes, byHostname: routesByHostname, byListenPort: routesByListenPort}, nil
 }
 
 // Simple logger implementation

--- a/main_test.go
+++ b/main_test.go
@@ -2429,6 +2429,58 @@ func TestHandleRequest_WakeLogNamesTheRoute(t *testing.T) {
 	<-done
 }
 
+// servesOneRequest drives handleRequest against a live, ready machine and returns
+// everything that was logged. The backend is dead, so the request 502s — the log
+// lines under test are written before any of that.
+func servesOneRequest(t *testing.T, prepare func(*http.Request)) string {
+	t.Helper()
+	logger := &recordingLogger{}
+	tp := newTestProxy(t, nil)
+	tp.svc.logger = logger
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	r := httptest.NewRequest("GET", "/api/server/ping", nil)
+	r.Host = testHostname
+	prepare(r)
+
+	tp.svc.handleRequest(httptest.NewRecorder(), r)
+	return logger.all()
+}
+
+func TestHandleRequest_LogsTheConnectingAddress(t *testing.T) {
+	// "Which route woke the box" is only half the question; the other half is who
+	// asked. Without the peer address the logs cannot tell a phone doing background
+	// sync from a monitor polling a health endpoint.
+	logged := servesOneRequest(t, func(r *http.Request) {
+		r.RemoteAddr = "10.0.0.42:51234"
+	})
+
+	if !strings.Contains(logged, "10.0.0.42:51234") {
+		t.Errorf("request log did not name the connecting address:\n%s", logged)
+	}
+}
+
+func TestHandleRequest_LogsForwardedForAlongsideThePeer(t *testing.T) {
+	// Behind a reverse proxy, RemoteAddr is that proxy and the original client is
+	// only in X-Forwarded-For. Report both: the peer is what actually connected,
+	// the header is a claim by whatever wrote it.
+	logged := servesOneRequest(t, func(r *http.Request) {
+		r.RemoteAddr = "10.0.0.1:443"
+		r.Header.Set("X-Forwarded-For", "203.0.113.7")
+	})
+
+	if !strings.Contains(logged, "10.0.0.1:443") {
+		t.Errorf("request log dropped the peer address:\n%s", logged)
+	}
+	if !strings.Contains(logged, "203.0.113.7") {
+		t.Errorf("request log dropped the forwarded-for client:\n%s", logged)
+	}
+}
+
 func TestHandleRequest_HealthyTarget(t *testing.T) {
 	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1009,6 +1010,49 @@ shutdown_http_url = "http://nas.local/api/shutdown"`},
 	}
 }
 
+func TestLoadConfig_RouteHealthCheckExplicitOrDerived(t *testing.T) {
+	cfg := machinesRoutesConfig + `
+[[routes]]
+machine = "nas"
+hostname = "photos.home.com"
+destination = "http://nas.local:2342"
+health_check = "http://nas.local:2342/ping"
+
+[[routes]]
+machine = "nas"
+listen_port = 2222
+destination = "nas.local:22"
+`
+	result, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	explicit := result.RoutesByHostname["photos.home.com"]
+	if explicit.HealthCheck != "http://nas.local:2342/ping" {
+		t.Errorf("an explicit health_check should win, got %q", explicit.HealthCheck)
+	}
+
+	derived := result.RoutesByHostname["files.home.com"]
+	if derived.HealthCheck != "tcp://nas.local:80" {
+		t.Errorf("HTTP route without health_check should dial its destination, got %q", derived.HealthCheck)
+	}
+
+	tcpRoute := result.RoutesByListenPort[2222]
+	if tcpRoute.HealthCheck != "tcp://nas.local:22" {
+		t.Errorf("TCP route without health_check should dial its destination, got %q", tcpRoute.HealthCheck)
+	}
+}
+
+func TestLoadConfig_RouteWithUndialableDestination(t *testing.T) {
+	cfg := strings.Replace(machinesRoutesConfig,
+		`destination = "http://nas.local"`, `destination = "nas.local"`, 1)
+	_, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+	if err == nil {
+		t.Fatal("expected an error for a destination that is neither a URL nor host:port")
+	}
+}
+
 func TestLoadConfig_EachLegacyTargetBecomesItsOwnMachineAndRoute(t *testing.T) {
 	cfg, err := LoadConfig(writeTempConfig(t, twoTargetConfig), RealClock{})
 	if err != nil {
@@ -1174,6 +1218,25 @@ func TestMigrateLegacyTargets_CarriesMachineAndRouteFields(t *testing.T) {
 	}
 }
 
+func TestMigrateLegacyTargets_HealthEndpointGatesBothLivenessAndReadiness(t *testing.T) {
+	// A legacy health_endpoint did double duty: it decided whether the box was up
+	// and whether the proxy could forward. Migration must preserve both, or a
+	// migrated config starts forwarding to a service that has not finished booting.
+	machines, routes := migrateLegacyTargets([]Target{{
+		Name:           "server",
+		Hostname:       "server.local",
+		Destination:    "http://192.168.1.10:80",
+		HealthEndpoint: "http://192.168.1.10:80/health",
+	}})
+
+	if machines[0].HealthCheck != "http://192.168.1.10:80/health" {
+		t.Errorf("machine liveness = %q, want the legacy health_endpoint", machines[0].HealthCheck)
+	}
+	if routes[0].HealthCheck != "http://192.168.1.10:80/health" {
+		t.Errorf("route readiness = %q, want the legacy health_endpoint", routes[0].HealthCheck)
+	}
+}
+
 func TestMigrateConfigFile_WritesAdoptableSidecar(t *testing.T) {
 	path := writeTempConfig(t, validConfig)
 	logger := &recordingLogger{}
@@ -1265,34 +1328,34 @@ func TestMigrateConfigFile_UnwritableDirectoryLogsTheConfigInstead(t *testing.T)
 // HTTPHealthChecker tests
 // ---------------------------------------------------------------------------
 
-func TestHTTPHealthChecker_Check_Healthy(t *testing.T) {
+func TestEndpointHealthChecker_Check_Healthy(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	}))
 	defer backend.Close()
 
-	hc := NewHTTPHealthChecker(noopLogger{}, RealClock{})
+	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
 	result := hc.Check(context.Background(), backend.URL+"/health", "test")
 	if !result {
 		t.Error("expected Check to return true for 200 response")
 	}
 }
 
-func TestHTTPHealthChecker_Check_Unhealthy(t *testing.T) {
+func TestEndpointHealthChecker_Check_Unhealthy(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
 	defer backend.Close()
 
-	hc := NewHTTPHealthChecker(noopLogger{}, RealClock{})
+	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
 	result := hc.Check(context.Background(), backend.URL+"/health", "test")
 	if result {
 		t.Error("expected Check to return false for 500 response")
 	}
 }
 
-func TestHTTPHealthChecker_Check_ConnectionRefused(t *testing.T) {
-	hc := NewHTTPHealthChecker(noopLogger{}, RealClock{})
+func TestEndpointHealthChecker_Check_ConnectionRefused(t *testing.T) {
+	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
 	result := hc.Check(context.Background(), "http://127.0.0.1:19998/health", "test")
 	if result {
 		t.Error("expected Check to return false for refused connection")
@@ -1302,6 +1365,70 @@ func TestHTTPHealthChecker_Check_ConnectionRefused(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Goroutine-driven unit tests (ManualClock + BlockUntil)
 // ---------------------------------------------------------------------------
+
+func TestHealthChecker_Check_TCPScheme(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+	t.Cleanup(func() { listener.Close() })
+
+	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
+
+	if !hc.Check(context.Background(), "tcp://"+listener.Addr().String(), "test") {
+		t.Error("expected a listening socket to be reported healthy")
+	}
+
+	listener.Close()
+	if hc.Check(context.Background(), "tcp://"+listener.Addr().String(), "test") {
+		t.Error("expected a closed socket to be reported unhealthy")
+	}
+}
+
+func TestHealthChecker_Check_TCPSchemeRejectsGarbageAddress(t *testing.T) {
+	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
+	if hc.Check(context.Background(), "tcp://", "test") {
+		t.Error("expected an empty tcp address to be unhealthy")
+	}
+}
+
+func TestDefaultHealthCheckForDestination(t *testing.T) {
+	tests := []struct {
+		destination string
+		want        string
+	}{
+		{"http://nas.local", "tcp://nas.local:80"},
+		{"https://nas.local", "tcp://nas.local:443"},
+		{"http://nas.local:2342", "tcp://nas.local:2342"},
+		{"https://nas.local:8443/base", "tcp://nas.local:8443"},
+		{"nas.local:22", "tcp://nas.local:22"},
+	}
+	for _, tc := range tests {
+		got, err := defaultHealthCheckForDestination(tc.destination)
+		if err != nil {
+			t.Errorf("defaultHealthCheckForDestination(%q) errored: %v", tc.destination, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("defaultHealthCheckForDestination(%q) = %q, want %q", tc.destination, got, tc.want)
+		}
+	}
+}
+
+func TestDefaultHealthCheckForDestination_RejectsHostWithoutPort(t *testing.T) {
+	if _, err := defaultHealthCheckForDestination("nas.local"); err == nil {
+		t.Error("a non-URL destination must carry a port; expected an error")
+	}
+}
 
 func TestWaitForWake_ContextCancel(t *testing.T) {
 	tp := newTestProxy(t, nil)
@@ -1764,12 +1891,12 @@ func TestE2E_WakeOnDemandAndProxy(t *testing.T) {
 // method-default logic, and inactivity/cache duration thresholds.
 // ---------------------------------------------------------------------------
 
-func TestHTTPHealthChecker_Check_Status300(t *testing.T) {
+func TestEndpointHealthChecker_Check_Status300(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(300)
 	}))
 	defer backend.Close()
-	hc := NewHTTPHealthChecker(noopLogger{}, RealClock{})
+	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
 	if hc.Check(context.Background(), backend.URL+"/health", "test") {
 		t.Error("expected Check to return false for status 300 (>= 300 is unhealthy)")
 	}
@@ -1913,7 +2040,7 @@ func TestBackgroundCheck_StampsLastCheckFromInjectedClock(t *testing.T) {
 	defer backend.Close()
 
 	clock := newManualClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
-	hc := NewHTTPHealthChecker(noopLogger{}, clock)
+	hc := NewEndpointHealthChecker(noopLogger{}, clock)
 
 	machine := &Machine{
 		Name:   testMachineName,
@@ -1969,7 +2096,7 @@ func TestBackgroundCheck_PeriodicTick_DowngradesToUnhealthy(t *testing.T) {
 	defer backend.Close()
 
 	clock := newManualClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
-	hc := NewHTTPHealthChecker(noopLogger{}, clock)
+	hc := NewEndpointHealthChecker(noopLogger{}, clock)
 
 	machine := &Machine{
 		Name:   testMachineName,

--- a/main_test.go
+++ b/main_test.go
@@ -4,8 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1206,6 +1214,126 @@ func TestLoadConfig_InactivityThreshold(t *testing.T) {
 	}
 }
 
+// writeSelfSignedCert writes a throwaway cert/key pair for 127.0.0.1 and returns
+// their paths, so the TLS branch is exercised through LoadX509KeyPair as configured.
+func writeSelfSignedCert(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
+}
+
+func TestServeHTTP_ServesTLSWhenCertificatesAreConfigured(t *testing.T) {
+	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	tp.svc.config.SSLCertificate, tp.svc.config.SSLCertificateKey = writeSelfSignedCert(t)
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	served := make(chan error, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", tp.svc.handleRequest)
+	go func() { served <- tp.svc.serveHTTP(ctx, &http.Server{Handler: mux}, listener) }()
+
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	url := "https://" + listener.Addr().String() + "/"
+
+	var resp *http.Response
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Host = testHostname
+		resp, err = client.Do(req)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("HTTPS request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if resp.TLS == nil {
+		t.Error("expected the connection to be TLS")
+	}
+
+	// A cancelled context must shut the server down cleanly, not surface an error.
+	cancel()
+	select {
+	case err := <-served:
+		if err != nil {
+			t.Errorf("serveHTTP returned %v on shutdown, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveHTTP did not return after the context was cancelled")
+	}
+}
+
+func TestServeHTTP_MissingCertificateIsReported(t *testing.T) {
+	tp := newTestProxy(t, nil)
+	tp.svc.config.SSLCertificate = filepath.Join(t.TempDir(), "absent.pem")
+	tp.svc.config.SSLCertificateKey = filepath.Join(t.TempDir(), "absent.key")
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	err = tp.svc.serveHTTP(context.Background(), &http.Server{}, listener)
+	if err == nil {
+		t.Fatal("expected an error when the configured certificate cannot be loaded")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TCP routes
 // ---------------------------------------------------------------------------
@@ -1557,6 +1685,55 @@ func TestCheckInactiveMachines_InFlightHTTPRequestBlocksShutdown(t *testing.T) {
 	waitFor(t, 5*time.Second, "the finished request to be released", func() bool {
 		return tp.machine.openConnections() == 0
 	})
+}
+
+func TestStart_CancelledContextShutsDownWithoutError(t *testing.T) {
+	// main() treats a non-nil return as fatal, so a clean shutdown must return nil.
+	tp := newTestProxy(t, nil)
+
+	free, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := free.Addr().(*net.TCPAddr).Port
+	free.Close()
+
+	route := &Route{
+		Name:        fmt.Sprintf(":%d", port),
+		Machine:     tp.machine,
+		ListenPort:  port,
+		Destination: "127.0.0.1:1",
+		HealthCheck: "tcp://127.0.0.1:1",
+	}
+	tp.svc.config.Routes = []*Route{route}
+	tp.svc.config.RoutesByHostname = map[string]*Route{}
+	tp.svc.config.RoutesByListenPort = map[int]*Route{port: route}
+	tp.svc.config.Port = "127.0.0.1:0"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { result <- tp.svc.Start(ctx) }()
+
+	// Give the listeners a moment to come up, then ask for shutdown.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Errorf("Start returned %v on a cancelled context, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after the context was cancelled")
+	}
+
+	// The TCP port must be released, or a restart would fail to bind.
+	reclaimed, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Errorf("TCP route port %d was not released on shutdown: %v", port, err)
+	} else {
+		reclaimed.Close()
+	}
 }
 
 func TestStart_ReportsWhichTCPPortCouldNotBeBound(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -1201,6 +1202,193 @@ func TestLoadConfig_InactivityThreshold(t *testing.T) {
 	}
 	if got := result.Machines["server"].Config.InactivityThreshold; got != 2*time.Hour {
 		t.Errorf("machine server InactivityThreshold = %v, want 2h", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TCP routes
+// ---------------------------------------------------------------------------
+
+// startEchoBackend returns the address of a TCP server that echoes what it reads.
+func startEchoBackend(t *testing.T) string {
+	t.Helper()
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { backend.Close() })
+
+	go func() {
+		for {
+			conn, err := backend.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				io.Copy(conn, conn)
+				conn.Close()
+			}()
+		}
+	}()
+	return backend.Addr().String()
+}
+
+// newTCPTestProxy wires a TCP route on the shared test machine and starts serving
+// it on an ephemeral port. It returns the proxy and the address to dial.
+func newTCPTestProxy(t *testing.T) (*testProxy, *Route, string) {
+	t.Helper()
+	tp := newTestProxy(t, nil)
+	backendAddr := startEchoBackend(t)
+
+	route := &Route{
+		Name:        ":0",
+		Machine:     tp.machine,
+		ListenPort:  1,
+		Destination: backendAddr,
+		HealthCheck: tcpScheme + backendAddr,
+		IsReady:     true,
+		LastCheck:   tp.clock.Now(),
+	}
+	tp.svc.config.Routes = []*Route{route}
+	tp.svc.config.RoutesByHostname = map[string]*Route{}
+	tp.svc.config.RoutesByListenPort = map[int]*Route{1: route}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { listener.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go tp.svc.serveTCPRoute(ctx, listener, route)
+
+	return tp, route, listener.Addr().String()
+}
+
+func TestTCPRoute_ForwardsBytesBothWays(t *testing.T) {
+	tp, _, proxyAddr := newTCPTestProxy(t)
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.LastActivity = tp.clock.Now().Add(-time.Hour)
+	tp.machine.mu.Unlock()
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("could not connect to the TCP route: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("hello sshd\n")); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	got, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if got != "hello sshd\n" {
+		t.Errorf("got %q, want the echoed payload", got)
+	}
+
+	tp.machine.mu.RLock()
+	lastActivity := tp.machine.LastActivity
+	tp.machine.mu.RUnlock()
+	if !lastActivity.Equal(tp.clock.Now()) {
+		t.Errorf("LastActivity = %v, want it bumped to %v by the TCP connection", lastActivity, tp.clock.Now())
+	}
+
+	if tp.wol.callCount() != 0 {
+		t.Error("a live machine should not be sent WOL packets")
+	}
+}
+
+func TestTCPRoute_WakesMachineBeforeForwarding(t *testing.T) {
+	tp, _, proxyAddr := newTCPTestProxy(t)
+
+	// The box is asleep; the health checker reports it up as soon as it is polled.
+	tp.health.setResult(true)
+
+	connErr := make(chan error, 1)
+	payload := make(chan string, 1)
+	go func() {
+		conn, err := net.Dial("tcp", proxyAddr)
+		if err != nil {
+			connErr <- err
+			return
+		}
+		defer conn.Close()
+		if _, err := conn.Write([]byte("wake me\n")); err != nil {
+			connErr <- err
+			return
+		}
+		conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		line, err := bufio.NewReader(conn).ReadString('\n')
+		if err != nil {
+			connErr <- err
+			return
+		}
+		payload <- line
+	}()
+
+	tp.wol.waitForCalls(t, 1, 5*time.Second)
+
+	// Let the wake poll fire.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		tp.clock.Advance(tp.svc.config.PollInterval)
+		select {
+		case line := <-payload:
+			if line != "wake me\n" {
+				t.Errorf("got %q, want the echoed payload", line)
+			}
+			return
+		case err := <-connErr:
+			t.Fatalf("connection failed: %v", err)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	t.Fatal("connection was never forwarded after the machine woke")
+}
+
+func TestStart_ReportsWhichTCPPortCouldNotBeBound(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer occupied.Close()
+	port := occupied.Addr().(*net.TCPAddr).Port
+
+	tp := newTestProxy(t, nil)
+	route := &Route{
+		Name:        fmt.Sprintf(":%d", port),
+		Machine:     tp.machine,
+		ListenPort:  port,
+		Destination: "127.0.0.1:1",
+		HealthCheck: "tcp://127.0.0.1:1",
+	}
+	tp.svc.config.Routes = []*Route{route}
+	tp.svc.config.RoutesByHostname = map[string]*Route{}
+	tp.svc.config.RoutesByListenPort = map[int]*Route{port: route}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() { result <- tp.svc.Start(ctx) }()
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected Start to fail when a TCP route's port is already in use")
+		}
+		if !strings.Contains(err.Error(), fmt.Sprint(port)) {
+			t.Errorf("error should name the port that could not be bound, got: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not report the unbindable TCP port; it kept running instead")
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -22,6 +23,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -2516,6 +2518,118 @@ func doRequest(t *testing.T, proxyURL string) *http.Response {
 		t.Fatalf("request failed: %v", err)
 	}
 	return resp
+}
+
+// scriptedListener returns a canned sequence of Accept errors, then parks until it
+// is closed. It stands in for a kernel that is transiently refusing to hand over
+// connections — out of file descriptors, or a client that reset during the handshake.
+type scriptedListener struct {
+	mu     sync.Mutex
+	calls  int
+	errs   []error
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newScriptedListener(errs ...error) *scriptedListener {
+	return &scriptedListener{errs: errs, closed: make(chan struct{})}
+}
+
+func (l *scriptedListener) Accept() (net.Conn, error) {
+	l.mu.Lock()
+	i := l.calls
+	l.calls++
+	l.mu.Unlock()
+
+	if i < len(l.errs) {
+		return nil, l.errs[i]
+	}
+	<-l.closed
+	return nil, net.ErrClosed
+}
+
+func (l *scriptedListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *scriptedListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2222}
+}
+
+func (l *scriptedListener) acceptCalls() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls
+}
+
+func TestServeTCPRoute_RetriesTransientAcceptErrors(t *testing.T) {
+	// Any Accept error used to end serveTCPRoute, which propagates through errs to
+	// Start and then to log.Fatalf in main. A transient ECONNABORTED — a client that
+	// resets during the handshake — would therefore take the whole proxy down,
+	// including every HTTP route. net/http's own Serve retries these with backoff.
+	listener := newScriptedListener(syscall.ECONNABORTED, syscall.ECONNABORTED, syscall.EMFILE)
+	t.Cleanup(func() { listener.Close() })
+
+	tp := newTestProxy(t, nil)
+	tp.svc.clock = RealClock{} // the retry backoff sleeps; keep it real and tiny
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() { result <- tp.svc.serveTCPRoute(ctx, listener, tp.route) }()
+
+	// It must ride out every scripted error and still be accepting afterwards.
+	waitFor(t, 5*time.Second, "the listener to be retried past its scripted errors", func() bool {
+		return listener.acceptCalls() > len(listener.errs)
+	})
+
+	select {
+	case err := <-result:
+		t.Fatalf("serveTCPRoute gave up on a transient accept error: %v", err)
+	default:
+	}
+
+	cancel()
+	listener.Close()
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Errorf("serveTCPRoute returned %v after cancellation, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveTCPRoute did not return after cancellation")
+	}
+}
+
+func TestServeTCPRoute_GivesUpOnPermanentAcceptErrors(t *testing.T) {
+	// Retrying must not swallow a genuinely broken listener: that error still has to
+	// reach Start so the operator sees it instead of a silent hot loop.
+	listener := newScriptedListener(errors.New("listener is broken beyond repair"))
+	t.Cleanup(func() { listener.Close() })
+
+	tp := newTestProxy(t, nil)
+	tp.svc.clock = RealClock{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() { result <- tp.svc.serveTCPRoute(ctx, listener, tp.route) }()
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("serveTCPRoute returned nil on a permanent accept error")
+		}
+		if !strings.Contains(err.Error(), "beyond repair") {
+			t.Errorf("error %v did not carry the underlying accept failure", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveTCPRoute hung on a permanent accept error instead of returning it")
+	}
 }
 
 func TestCheckTCP_CapsTheDialItself(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -752,6 +752,142 @@ broadcast_ip = "255.255.255.255"
 wol_port = 9
 `
 
+// mustContain fails unless err is non-nil and mentions each fragment. Config errors
+// are read by an operator at startup, so what they say is the feature.
+func mustContain(t *testing.T, err error, fragments ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a config error, got nil")
+	}
+	for _, fragment := range fragments {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Errorf("error %q does not mention %q", err, fragment)
+		}
+	}
+}
+
+const machineAndRouteHeader = `
+port = "8080"
+timeout = "1m"
+poll_interval = "5s"
+health_check_interval = "30s"
+health_cache_duration = "10s"
+`
+
+func TestLoadConfig_MachineNeedsAHealthCheck(t *testing.T) {
+	// Without it every Check hits checkHTTP with an empty endpoint, fails with
+	// `unsupported protocol scheme ""`, and leaves the machine permanently unhealthy:
+	// every request then wakes it, spraying WOL for the whole timeout before a 503.
+	_, err := LoadConfig(writeTempConfig(t, machineAndRouteHeader+`
+[[machines]]
+name = "nas"
+mac_address = "AA:BB:CC:DD:EE:FF"
+
+[[routes]]
+machine = "nas"
+hostname = "files.home.com"
+destination = "http://nas.local"
+`), RealClock{})
+
+	mustContain(t, err, "nas", "health_check")
+}
+
+func TestLoadConfig_TCPRouteDestinationMustCarryAPort(t *testing.T) {
+	// An explicit health_check skipped the only code path that validated destination,
+	// so this used to load and then fail per connection — after the client had been
+	// accepted and the machine woken.
+	_, err := LoadConfig(writeTempConfig(t, machineAndRouteHeader+`
+[[machines]]
+name = "nas"
+health_check = "tcp://nas.local:22"
+
+[[routes]]
+machine = "nas"
+listen_port = 2222
+destination = "nas.local"
+health_check = "tcp://nas.local:22"
+`), RealClock{})
+
+	mustContain(t, err, "nas.local", "host:port")
+}
+
+func TestLoadConfig_HTTPRouteDestinationMustBeAnHTTPURL(t *testing.T) {
+	// url.Parse accepts "nas.local:2342" happily — as scheme "nas.local" with opaque
+	// body "2342", since dots are legal in scheme names. The reverse proxy is then
+	// built on nonsense and 502s every request with nothing explaining why.
+	_, err := LoadConfig(writeTempConfig(t, machineAndRouteHeader+`
+[[machines]]
+name = "nas"
+health_check = "tcp://nas.local:22"
+
+[[routes]]
+machine = "nas"
+hostname = "photos.home.com"
+destination = "nas.local:2342"
+health_check = "tcp://nas.local:2342"
+`), RealClock{})
+
+	mustContain(t, err, "nas.local:2342", "http")
+}
+
+func TestLoadConfig_RejectsUnknownKeys(t *testing.T) {
+	// BurntSushi reports unmatched keys through MetaData.Undecoded, which LoadConfig
+	// used to discard. A misspelling therefore decoded silently into a zero value,
+	// which is how an empty health_check gets into a config in the first place.
+	_, err := LoadConfig(writeTempConfig(t, machineAndRouteHeader+`
+[[machines]]
+name = "nas"
+health_chek = "tcp://nas.local:22"
+
+[[routes]]
+machine = "nas"
+hostname = "files.home.com"
+destination = "http://nas.local"
+`), RealClock{})
+
+	mustContain(t, err, "health_chek")
+}
+
+func TestLoadConfig_AcceptsTheShippedExampleConfig(t *testing.T) {
+	// The documented example must survive every rule added here, or the rules are
+	// wrong. Guards the strict unknown-key check against the config we ship.
+	if _, err := LoadConfig("config.toml", RealClock{}); err != nil {
+		t.Fatalf("the shipped config.toml no longer loads: %v", err)
+	}
+}
+
+func TestMigrateConfigFile_OutputLoadsUnderTheSameRules(t *testing.T) {
+	// The sidecar is offered to operators as a drop-in replacement, so it has to pass
+	// the validation the loader now applies. A migration that emits a config the
+	// loader rejects is worse than no migration at all.
+	path := writeTempConfig(t, validConfig)
+	MigrateConfigFile(path, &recordingLogger{})
+
+	migrated := strings.TrimSuffix(path, ".toml") + ".migrated.toml"
+	if _, err := os.Stat(migrated); err != nil {
+		t.Fatalf("migration wrote no sidecar: %v", err)
+	}
+
+	if _, err := LoadConfig(migrated, RealClock{}); err != nil {
+		t.Fatalf("the migrated config does not load: %v", err)
+	}
+}
+
+func TestLoadConfig_LegacyTargetWithoutHealthEndpointIsRejected(t *testing.T) {
+	// A legacy target with no health_endpoint migrates to a machine with no
+	// health_check, which is exactly the permanently-unhealthy case above. It should
+	// fail at load, and the message should name the key the operator actually wrote.
+	_, err := LoadConfig(writeTempConfig(t, machineAndRouteHeader+`
+[[targets]]
+name = "server"
+hostname = "server.local"
+destination = "http://192.168.1.10:80"
+mac_address = "AA:BB:CC:DD:EE:FF"
+`), RealClock{})
+
+	mustContain(t, err, "server", "health_endpoint")
+}
+
 func TestLoadConfig_Valid(t *testing.T) {
 	cfg, err := LoadConfig(writeTempConfig(t, validConfig), RealClock{})
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -723,6 +723,248 @@ broadcast_ip = "255.255.255.255"
 wol_port = 9
 `
 
+const machinesRoutesConfig = `
+port = "8080"
+timeout = "1m"
+poll_interval = "5s"
+health_check_interval = "30s"
+health_cache_duration = "10s"
+
+[[machines]]
+name = "nas"
+mac_address = "AA:BB:CC:DD:EE:FF"
+broadcast_ip = "255.255.255.255"
+wol_port = 9
+health_check = "tcp://nas.local:22"
+inactivity_threshold = "1h"
+ssh_host = "nas.local:22"
+ssh_user = "wol-proxy"
+ssh_key_path = "/app/private_key"
+shutdown_command = "sudo systemctl suspend"
+
+[[routes]]
+machine = "nas"
+hostname = "files.home.com"
+destination = "http://nas.local"
+`
+
+func TestLoadConfig_MachinesAndRoutes(t *testing.T) {
+	cfg, err := LoadConfig(writeTempConfig(t, machinesRoutesConfig), RealClock{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	machine, ok := cfg.Machines["nas"]
+	if !ok {
+		t.Fatalf("expected machine 'nas', got %v", cfg.Machines)
+	}
+	if machine.Config.MacAddress != "AA:BB:CC:DD:EE:FF" {
+		t.Errorf("MacAddress = %q", machine.Config.MacAddress)
+	}
+	if machine.Config.HealthCheck != "tcp://nas.local:22" {
+		t.Errorf("HealthCheck = %q", machine.Config.HealthCheck)
+	}
+	if machine.Config.InactivityThreshold != time.Hour {
+		t.Errorf("InactivityThreshold = %v, want 1h", machine.Config.InactivityThreshold)
+	}
+	if machine.Config.ShutdownCommand != "sudo systemctl suspend" {
+		t.Errorf("ShutdownCommand = %q", machine.Config.ShutdownCommand)
+	}
+
+	route, ok := cfg.RoutesByHostname["files.home.com"]
+	if !ok {
+		t.Fatalf("expected a route for files.home.com, got %v", cfg.RoutesByHostname)
+	}
+	if route.Destination != "http://nas.local" {
+		t.Errorf("Destination = %q", route.Destination)
+	}
+	if route.Machine != machine {
+		t.Error("route should point at the 'nas' machine")
+	}
+}
+
+func TestLoadConfig_ManyRoutesShareOneMachine(t *testing.T) {
+	cfg := machinesRoutesConfig + `
+[[routes]]
+machine = "nas"
+hostname = "photos.home.com"
+destination = "http://nas.local:2342"
+
+[[routes]]
+machine = "nas"
+listen_port = 2222
+destination = "nas.local:22"
+`
+	result, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Machines) != 1 {
+		t.Errorf("Machines = %d, want 1", len(result.Machines))
+	}
+	if len(result.Routes) != 3 {
+		t.Fatalf("Routes = %d, want 3", len(result.Routes))
+	}
+
+	machine := result.Machines["nas"]
+	for _, route := range result.Routes {
+		if route.Machine != machine {
+			t.Errorf("route %s points at a different Machine value; all three must share one", route.Name)
+		}
+	}
+
+	tcpRoutes := 0
+	for _, route := range result.Routes {
+		if route.IsTCP() {
+			tcpRoutes++
+			if route.ListenPort != 2222 {
+				t.Errorf("TCP route ListenPort = %d, want 2222", route.ListenPort)
+			}
+			if route.Destination != "nas.local:22" {
+				t.Errorf("TCP route Destination = %q", route.Destination)
+			}
+		}
+	}
+	if tcpRoutes != 1 {
+		t.Errorf("TCP routes = %d, want 1", tcpRoutes)
+	}
+}
+
+func TestLoadConfig_RouteReferencingUnknownMachine(t *testing.T) {
+	cfg := machinesRoutesConfig + `
+[[routes]]
+machine = "typo"
+hostname = "other.home.com"
+destination = "http://nas.local"
+`
+	_, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+	if err == nil {
+		t.Fatal("expected an error for a route referencing an undefined machine")
+	}
+	if !strings.Contains(err.Error(), "typo") {
+		t.Errorf("error should name the unknown machine, got: %v", err)
+	}
+}
+
+func TestLoadConfig_DuplicateMachineName(t *testing.T) {
+	cfg := machinesRoutesConfig + `
+[[machines]]
+name = "nas"
+mac_address = "11:22:33:44:55:66"
+health_check = "tcp://other.local:22"
+`
+	_, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+	if err == nil {
+		t.Fatal("expected an error for two machines sharing a name")
+	}
+	if !strings.Contains(err.Error(), "nas") {
+		t.Errorf("error should name the duplicated machine, got: %v", err)
+	}
+}
+
+func TestLoadConfig_MachineWithoutName(t *testing.T) {
+	// No routes, so the only thing that can fail is the missing machine name.
+	cfg := `
+port = "8080"
+timeout = "1m"
+poll_interval = "5s"
+health_check_interval = "30s"
+health_cache_duration = "10s"
+
+[[machines]]
+mac_address = "AA:BB:CC:DD:EE:FF"
+health_check = "tcp://nas.local:22"
+`
+	_, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+	if err == nil {
+		t.Fatal("expected an error for a machine with no name")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error should point at the missing name, got: %v", err)
+	}
+}
+
+func TestLoadConfig_DuplicateHostnameAcrossRoutes(t *testing.T) {
+	cfg := machinesRoutesConfig + `
+[[routes]]
+machine = "nas"
+hostname = "files.home.com"
+destination = "http://nas.local:9999"
+`
+	_, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+	if err == nil {
+		t.Fatal("expected an error for two routes sharing a hostname")
+	}
+	if !strings.Contains(err.Error(), "files.home.com") {
+		t.Errorf("error should name the duplicated hostname, got: %v", err)
+	}
+}
+
+func TestLoadConfig_DuplicateListenPortAcrossRoutes(t *testing.T) {
+	cfg := machinesRoutesConfig + `
+[[routes]]
+machine = "nas"
+listen_port = 2222
+destination = "nas.local:22"
+
+[[routes]]
+machine = "nas"
+listen_port = 2222
+destination = "nas.local:23"
+`
+	_, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+	if err == nil {
+		t.Fatal("expected an error for two routes sharing a listen port")
+	}
+	if !strings.Contains(err.Error(), "2222") {
+		t.Errorf("error should name the duplicated port, got: %v", err)
+	}
+}
+
+func TestLoadConfig_RouteMustHaveExactlyOneOfHostnameOrListenPort(t *testing.T) {
+	tests := []struct {
+		name  string
+		route string
+	}{
+		{"neither", `
+[[routes]]
+machine = "nas"
+destination = "http://nas.local"
+`},
+		{"both", `
+[[routes]]
+machine = "nas"
+hostname = "both.home.com"
+listen_port = 3333
+destination = "http://nas.local"
+`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadConfig(writeTempConfig(t, machinesRoutesConfig+tc.route), RealClock{})
+			if err == nil {
+				t.Fatal("expected an error: a route is reached by hostname or by listen port, never neither or both")
+			}
+		})
+	}
+}
+
+func TestLoadConfig_LegacyAndNewFormatTogether(t *testing.T) {
+	cfg := machinesRoutesConfig + `
+[[targets]]
+name = "old"
+hostname = "old.home.com"
+destination = "http://old.local"
+health_endpoint = "http://old.local/ping"
+mac_address = "99:88:77:66:55:44"
+`
+	_, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+	if err == nil {
+		t.Fatal("expected an error when a config mixes [[targets]] with [[machines]]")
+	}
+}
+
 func TestLoadConfig_EachLegacyTargetBecomesItsOwnMachineAndRoute(t *testing.T) {
 	cfg, err := LoadConfig(writeTempConfig(t, twoTargetConfig), RealClock{})
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -2001,6 +2001,48 @@ func TestHandleRequest_HealthyTarget(t *testing.T) {
 	}
 }
 
+func TestHandleRequest_ExpiredReadinessCache_ServesWithoutWaitingForAPollTick(t *testing.T) {
+	// Background checks refresh readiness every health_check_interval but the cache
+	// only lasts health_cache_duration, so there is a window where readiness is stale
+	// on a route that is perfectly fine. Requests in that window must not pay a full
+	// poll interval of latency.
+	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	tp.route.mu.Lock()
+	tp.route.IsReady = true
+	tp.route.LastCheck = tp.clock.Now().Add(-2 * tp.svc.config.HealthCacheDuration)
+	tp.route.mu.Unlock()
+
+	tp.health.setResult(true)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Host = testHostname
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		tp.svc.handleRequest(w, r)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleRequest waited for a poll tick instead of re-checking readiness immediately")
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
 func TestHandleRequest_LiveMachineButUnreadyRoute_WaitsInsteadOfForwarding(t *testing.T) {
 	var served int32
 	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/main_test.go
+++ b/main_test.go
@@ -278,6 +278,25 @@ func (m *mockSSHExecutor) ExecuteCommand(_, _, _, _ string) error {
 	return m.err
 }
 
+type recordingLogger struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *recordingLogger) Info(msg string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, fmt.Sprintf(msg, args...))
+}
+
+func (l *recordingLogger) Error(msg string, args ...interface{}) { l.Info(msg, args...) }
+
+func (l *recordingLogger) all() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.lines, "\n")
+}
+
 type noopLogger struct{}
 
 func (noopLogger) Info(_ string, _ ...interface{})  {}
@@ -965,6 +984,31 @@ mac_address = "99:88:77:66:55:44"
 	}
 }
 
+func TestLoadConfig_MachineShutdownValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		extra string
+	}{
+		{"both ssh and http shutdown", `shutdown_command = "sudo systemctl suspend"
+shutdown_http_url = "http://nas.local/api/shutdown"`},
+		{"http method without url", `shutdown_http_method = "PUT"`},
+		{"http ok status without url", `shutdown_http_ok_status = 202`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := strings.Replace(machinesRoutesConfig,
+				`shutdown_command = "sudo systemctl suspend"`, tc.extra, 1)
+			_, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+			if err == nil {
+				t.Fatal("expected a validation error")
+			}
+			if !strings.Contains(err.Error(), "nas") {
+				t.Errorf("error should name the machine, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestLoadConfig_EachLegacyTargetBecomesItsOwnMachineAndRoute(t *testing.T) {
 	cfg, err := LoadConfig(writeTempConfig(t, twoTargetConfig), RealClock{})
 	if err != nil {
@@ -1067,6 +1111,153 @@ func TestLoadConfig_InactivityThreshold(t *testing.T) {
 	}
 	if got := result.Machines["server"].Config.InactivityThreshold; got != 2*time.Hour {
 		t.Errorf("machine server InactivityThreshold = %v, want 2h", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Legacy config migration
+// ---------------------------------------------------------------------------
+
+func TestMigrateLegacyTargets_CarriesMachineAndRouteFields(t *testing.T) {
+	targets := []Target{{
+		Name:                 "server",
+		Hostname:             "server.local",
+		Destination:          "http://192.168.1.10:80",
+		HealthEndpoint:       "http://192.168.1.10:80/health",
+		MacAddress:           "AA:BB:CC:DD:EE:FF",
+		BroadcastIP:          "255.255.255.255",
+		WolPort:              9,
+		SSHHost:              "server.local:22",
+		SSHUser:              "admin",
+		SSHKeyPath:           "/key",
+		ShutdownCommand:      "suspend",
+		ShutdownHTTPMethod:   "",
+		ShutdownHTTPOKStatus: 0,
+		InactivityThreshold:  "1h",
+	}}
+
+	machines, routes := migrateLegacyTargets(targets)
+
+	if len(machines) != 1 || len(routes) != 1 {
+		t.Fatalf("got %d machines and %d routes, want 1 and 1", len(machines), len(routes))
+	}
+
+	m := machines[0]
+	if m.Name != "server" {
+		t.Errorf("machine Name = %q", m.Name)
+	}
+	if m.MacAddress != "AA:BB:CC:DD:EE:FF" || m.BroadcastIP != "255.255.255.255" || m.WolPort != 9 {
+		t.Errorf("WOL fields not carried: %+v", m)
+	}
+	if m.SSHHost != "server.local:22" || m.SSHUser != "admin" || m.SSHKeyPath != "/key" || m.ShutdownCommand != "suspend" {
+		t.Errorf("shutdown fields not carried: %+v", m)
+	}
+	if m.InactivityThreshold != "1h" {
+		t.Errorf("InactivityThreshold = %q, want 1h", m.InactivityThreshold)
+	}
+	if m.HealthCheck != "http://192.168.1.10:80/health" {
+		t.Errorf("machine HealthCheck should come from health_endpoint, got %q", m.HealthCheck)
+	}
+
+	r := routes[0]
+	if r.Machine != "server" {
+		t.Errorf("route Machine = %q, want server", r.Machine)
+	}
+	if r.Hostname != "server.local" {
+		t.Errorf("route Hostname = %q", r.Hostname)
+	}
+	if r.Destination != "http://192.168.1.10:80" {
+		t.Errorf("route Destination = %q", r.Destination)
+	}
+	if r.ListenPort != 0 {
+		t.Errorf("a migrated legacy target is an HTTP route, got ListenPort %d", r.ListenPort)
+	}
+}
+
+func TestMigrateConfigFile_WritesAdoptableSidecar(t *testing.T) {
+	path := writeTempConfig(t, validConfig)
+	logger := &recordingLogger{}
+
+	MigrateConfigFile(path, logger)
+
+	sidecar := filepath.Join(filepath.Dir(path), "wol-proxy-test.migrated.toml")
+	written, err := os.ReadFile(sidecar)
+	if err != nil {
+		t.Fatalf("expected a migrated config beside the original: %v", err)
+	}
+	if !strings.Contains(string(written), "[[machines]]") || !strings.Contains(string(written), "[[routes]]") {
+		t.Errorf("sidecar should be in the new format, got:\n%s", written)
+	}
+	if strings.Contains(string(written), "[[targets]]") {
+		t.Errorf("sidecar should not carry the legacy format, got:\n%s", written)
+	}
+	// An adoptable config carries only keys the operator actually set.
+	for _, unset := range []string{"= 0", `= ""`, "listen_port"} {
+		if strings.Contains(string(written), unset) {
+			t.Errorf("sidecar should omit unset keys but contains %q:\n%s", unset, written)
+		}
+	}
+	if !strings.Contains(logger.all(), sidecar) {
+		t.Errorf("operator should be told where the migrated config went, got: %s", logger.all())
+	}
+
+	// The whole point: the sidecar loads to the same model as the legacy original.
+	fromLegacy, err := LoadConfig(path, RealClock{})
+	if err != nil {
+		t.Fatalf("legacy config failed to load: %v", err)
+	}
+	fromSidecar, err := LoadConfig(sidecar, RealClock{})
+	if err != nil {
+		t.Fatalf("migrated config failed to load: %v", err)
+	}
+	if len(fromSidecar.Machines) != len(fromLegacy.Machines) || len(fromSidecar.Routes) != len(fromLegacy.Routes) {
+		t.Fatalf("migrated model differs: %d machines/%d routes vs %d/%d",
+			len(fromSidecar.Machines), len(fromSidecar.Routes), len(fromLegacy.Machines), len(fromLegacy.Routes))
+	}
+	legacyRoute := fromLegacy.RoutesByHostname["server.local"]
+	sidecarRoute := fromSidecar.RoutesByHostname["server.local"]
+	if sidecarRoute == nil {
+		t.Fatal("migrated config lost the server.local route")
+	}
+	if sidecarRoute.Destination != legacyRoute.Destination {
+		t.Errorf("Destination %q != %q", sidecarRoute.Destination, legacyRoute.Destination)
+	}
+	if sidecarRoute.Machine.Config.HealthCheck != legacyRoute.Machine.Config.HealthCheck {
+		t.Errorf("HealthCheck %q != %q", sidecarRoute.Machine.Config.HealthCheck, legacyRoute.Machine.Config.HealthCheck)
+	}
+	if sidecarRoute.Machine.Config.MacAddress != legacyRoute.Machine.Config.MacAddress {
+		t.Errorf("MacAddress %q != %q", sidecarRoute.Machine.Config.MacAddress, legacyRoute.Machine.Config.MacAddress)
+	}
+}
+
+func TestMigrateConfigFile_LeavesNewFormatAlone(t *testing.T) {
+	path := writeTempConfig(t, machinesRoutesConfig)
+
+	MigrateConfigFile(path, &recordingLogger{})
+
+	sidecar := filepath.Join(filepath.Dir(path), "wol-proxy-test.migrated.toml")
+	if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+		t.Errorf("no sidecar should be written for a config already in the new format (stat err: %v)", err)
+	}
+}
+
+func TestMigrateConfigFile_UnwritableDirectoryLogsTheConfigInstead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(validConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o700) })
+
+	logger := &recordingLogger{}
+	MigrateConfigFile(path, logger)
+
+	logged := logger.all()
+	if !strings.Contains(logged, "[[machines]]") {
+		t.Errorf("when the sidecar cannot be written the migrated config should be logged, got: %s", logged)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -192,7 +192,7 @@ func (m *mockHealthChecker) Check(_ context.Context, _, _ string) bool {
 	return m.result
 }
 
-func (m *mockHealthChecker) StartBackgroundChecks(_ context.Context, _ map[string]*TargetState, _ time.Duration) {
+func (m *mockHealthChecker) StartBackgroundChecks(_ context.Context, _ map[string]*MachineState, _ time.Duration) {
 }
 func (m *mockHealthChecker) WaitForInitialChecks(_ context.Context) error { return nil }
 func (m *mockHealthChecker) CloseIdleConnections()                        {}
@@ -293,15 +293,17 @@ type testProxy struct {
 	health  *mockHealthChecker
 	wol     *mockWOLSender
 	ssh     *mockSSHExecutor
-	target  *TargetState
+	machine *MachineState
+	route   *Route
 	backend *httptest.Server
 }
 
 const testHostname = "server.local"
-const testTargetName = "server"
+const testMachineName = "server"
 
-// newTestProxy builds a ProxyService with one target, all mocks, and optionally
-// a real httptest backend. Pass backendHandler=nil for tests that don't proxy.
+// newTestProxy builds a ProxyService with one machine and one route pointing at
+// it, all mocks, and optionally a real httptest backend. Pass backendHandler=nil
+// for tests that don't proxy.
 func newTestProxy(t *testing.T, backendHandler http.Handler) *testProxy {
 	t.Helper()
 
@@ -320,73 +322,82 @@ func newTestProxy(t *testing.T, backendHandler http.Handler) *testProxy {
 		backendURL = "http://127.0.0.1:19999" // unused port
 	}
 
-	tgt := &Target{
-		Name:            testTargetName,
-		Hostname:        testHostname,
-		Destination:     backendURL,
-		HealthEndpoint:  backendURL + "/health",
-		MacAddress:      "AA:BB:CC:DD:EE:FF",
-		BroadcastIP:     "255.255.255.255",
-		WolPort:         9,
-		SSHHost:         "server.local",
-		SSHUser:         "admin",
-		SSHKeyPath:      "/home/admin/.ssh/id_rsa",
-		ShutdownCommand: "shutdown -h now",
-	}
-
-	targetState := &TargetState{
-		Target:       tgt,
+	machineState := &MachineState{
+		Machine: &Machine{
+			Name:            testMachineName,
+			HealthCheck:     backendURL + "/health",
+			MacAddress:      "AA:BB:CC:DD:EE:FF",
+			BroadcastIP:     "255.255.255.255",
+			WolPort:         9,
+			SSHHost:         "server.local",
+			SSHUser:         "admin",
+			SSHKeyPath:      "/home/admin/.ssh/id_rsa",
+			ShutdownCommand: "shutdown -h now",
+		},
 		LastActivity: clock.Now(),
 	}
 
+	route := &Route{
+		Name:        testMachineName,
+		Machine:     machineState,
+		Hostname:    testHostname,
+		Destination: backendURL,
+	}
+
 	cfg := &ProxyConfig{
-		Port:                 ":0",
-		Timeout:              5 * time.Second,
-		PollInterval:         1 * time.Second,
-		HealthCheckInterval:  30 * time.Second,
-		HealthCacheDuration:  10 * time.Second,
-		Targets:              map[string]*TargetState{testTargetName: targetState},
-		HostnameMap:          map[string]string{testHostname: testTargetName},
-		InactivityThresholds: map[string]time.Duration{},
+		Port:                ":0",
+		Timeout:             5 * time.Second,
+		PollInterval:        1 * time.Second,
+		HealthCheckInterval: 30 * time.Second,
+		HealthCacheDuration: 10 * time.Second,
+		Machines:            map[string]*MachineState{testMachineName: machineState},
+		Routes:              []*Route{route},
+		RoutesByHostname:    map[string]*Route{testHostname: route},
 	}
 
 	svc := NewProxyService(cfg, health, wol, ssh, noopLogger{}, clock)
 
-	return &testProxy{svc: svc, clock: clock, health: health, wol: wol, ssh: ssh, target: targetState, backend: backend}
+	return &testProxy{svc: svc, clock: clock, health: health, wol: wol, ssh: ssh, machine: machineState, route: route, backend: backend}
 }
 
 // ---------------------------------------------------------------------------
 // Unit tests — pure logic
 // ---------------------------------------------------------------------------
 
-func TestExtractTarget(t *testing.T) {
+func TestRouteForRequest(t *testing.T) {
 	tp := newTestProxy(t, nil)
 
 	tests := []struct {
-		host string
-		want string
+		host      string
+		wantRoute bool
 	}{
-		{testHostname, testTargetName},
-		{testHostname + ":8080", testTargetName},
-		{"unknown.host", ""},
-		{"", ""},
+		{testHostname, true},
+		{testHostname + ":8080", true},
+		{"unknown.host", false},
+		{"", false},
 	}
 	for _, tc := range tests {
 		r := httptest.NewRequest("GET", "/", nil)
 		r.Host = tc.host
-		got := tp.svc.extractTarget(r)
-		if got != tc.want {
-			t.Errorf("extractTarget(%q) = %q, want %q", tc.host, got, tc.want)
+		got := tp.svc.routeForRequest(r)
+		if tc.wantRoute {
+			if got != tp.route {
+				t.Errorf("routeForRequest(%q) = %v, want the configured route", tc.host, got)
+			}
+			continue
+		}
+		if got != nil {
+			t.Errorf("routeForRequest(%q) = %v, want no route", tc.host, got)
 		}
 	}
 }
 
 func TestHealthCacheStatus_HealthyFresh(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.target.IsHealthy = true
-	tp.target.LastCheck = tp.clock.Now().Add(-5 * time.Second) // 5s ago, cache=10s
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now().Add(-5 * time.Second) // 5s ago, cache=10s
 
-	cached, reason := tp.svc.healthCacheStatus(tp.target)
+	cached, reason := tp.svc.healthCacheStatus(tp.machine)
 	if !cached {
 		t.Errorf("expected cached=true, got false; reason: %s", reason)
 	}
@@ -394,10 +405,10 @@ func TestHealthCacheStatus_HealthyFresh(t *testing.T) {
 
 func TestHealthCacheStatus_HealthyExpired(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.target.IsHealthy = true
-	tp.target.LastCheck = tp.clock.Now().Add(-15 * time.Second) // 15s ago, cache=10s
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now().Add(-15 * time.Second) // 15s ago, cache=10s
 
-	cached, _ := tp.svc.healthCacheStatus(tp.target)
+	cached, _ := tp.svc.healthCacheStatus(tp.machine)
 	if cached {
 		t.Error("expected cached=false for expired cache")
 	}
@@ -405,10 +416,10 @@ func TestHealthCacheStatus_HealthyExpired(t *testing.T) {
 
 func TestHealthCacheStatus_Unhealthy(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.target.IsHealthy = false
-	tp.target.LastCheck = tp.clock.Now().Add(-2 * time.Second)
+	tp.machine.IsHealthy = false
+	tp.machine.LastCheck = tp.clock.Now().Add(-2 * time.Second)
 
-	cached, reason := tp.svc.healthCacheStatus(tp.target)
+	cached, reason := tp.svc.healthCacheStatus(tp.machine)
 	if cached {
 		t.Errorf("expected cached=false for unhealthy target, reason: %s", reason)
 	}
@@ -416,10 +427,10 @@ func TestHealthCacheStatus_Unhealthy(t *testing.T) {
 
 func TestHealthCacheStatus_NoCheck(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.target.IsHealthy = false
+	tp.machine.IsHealthy = false
 	// LastCheck is zero value
 
-	cached, reason := tp.svc.healthCacheStatus(tp.target)
+	cached, reason := tp.svc.healthCacheStatus(tp.machine)
 	if cached {
 		t.Error("expected cached=false when no prior health check")
 	}
@@ -430,14 +441,14 @@ func TestHealthCacheStatus_NoCheck(t *testing.T) {
 
 func TestCheckInactiveTargets_InactiveHealthy_TriggersShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.svc.config.InactivityThresholds[testTargetName] = 30 * time.Minute
+	tp.machine.Machine.InactivityThreshold = 30 * time.Minute
 
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = true
-	tp.target.LastActivity = tp.clock.Now().Add(-1 * time.Hour)
-	tp.target.mu.Unlock()
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastActivity = tp.clock.Now().Add(-1 * time.Hour)
+	tp.machine.mu.Unlock()
 
-	tp.svc.checkInactiveTargets()
+	tp.svc.checkInactiveMachines()
 
 	select {
 	case <-tp.ssh.done:
@@ -448,14 +459,14 @@ func TestCheckInactiveTargets_InactiveHealthy_TriggersShutdown(t *testing.T) {
 
 func TestCheckInactiveTargets_InactiveUnhealthy_NoShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.svc.config.InactivityThresholds[testTargetName] = 30 * time.Minute
+	tp.machine.Machine.InactivityThreshold = 30 * time.Minute
 
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = false
-	tp.target.LastActivity = tp.clock.Now().Add(-1 * time.Hour)
-	tp.target.mu.Unlock()
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = false
+	tp.machine.LastActivity = tp.clock.Now().Add(-1 * time.Hour)
+	tp.machine.mu.Unlock()
 
-	tp.svc.checkInactiveTargets()
+	tp.svc.checkInactiveMachines()
 
 	select {
 	case <-tp.ssh.done:
@@ -466,14 +477,14 @@ func TestCheckInactiveTargets_InactiveUnhealthy_NoShutdown(t *testing.T) {
 
 func TestCheckInactiveTargets_Active_NoShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.svc.config.InactivityThresholds[testTargetName] = 30 * time.Minute
+	tp.machine.Machine.InactivityThreshold = 30 * time.Minute
 
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = true
-	tp.target.LastActivity = tp.clock.Now().Add(-5 * time.Minute) // well within threshold
-	tp.target.mu.Unlock()
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastActivity = tp.clock.Now().Add(-5 * time.Minute) // well within threshold
+	tp.machine.mu.Unlock()
 
-	tp.svc.checkInactiveTargets()
+	tp.svc.checkInactiveMachines()
 
 	select {
 	case <-tp.ssh.done:
@@ -484,14 +495,14 @@ func TestCheckInactiveTargets_Active_NoShutdown(t *testing.T) {
 
 func TestCheckInactiveTargets_NoThreshold_NoShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	// InactivityThresholds is empty by default in newTestProxy
+	// InactivityThreshold is unset by default in newTestProxy
 
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = true
-	tp.target.LastActivity = tp.clock.Now().Add(-48 * time.Hour)
-	tp.target.mu.Unlock()
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastActivity = tp.clock.Now().Add(-48 * time.Hour)
+	tp.machine.mu.Unlock()
 
-	tp.svc.checkInactiveTargets()
+	tp.svc.checkInactiveMachines()
 
 	select {
 	case <-tp.ssh.done:
@@ -502,9 +513,9 @@ func TestCheckInactiveTargets_NoThreshold_NoShutdown(t *testing.T) {
 
 func TestShutdownTarget_SSH(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.target.IsHealthy = true
+	tp.machine.IsHealthy = true
 
-	err := tp.svc.shutdownTarget(testTargetName)
+	err := tp.svc.shutdownMachine(testMachineName)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -515,9 +526,9 @@ func TestShutdownTarget_SSH(t *testing.T) {
 		t.Error("expected SSH executor to be called")
 	}
 
-	tp.target.mu.RLock()
-	healthy := tp.target.IsHealthy
-	tp.target.mu.RUnlock()
+	tp.machine.mu.RLock()
+	healthy := tp.machine.IsHealthy
+	tp.machine.mu.RUnlock()
 	if healthy {
 		t.Error("expected IsHealthy=false after shutdown")
 	}
@@ -526,9 +537,9 @@ func TestShutdownTarget_SSH(t *testing.T) {
 func TestShutdownTarget_SSH_Error(t *testing.T) {
 	tp := newTestProxy(t, nil)
 	tp.ssh.err = fmt.Errorf("connection refused")
-	tp.target.IsHealthy = true
+	tp.machine.IsHealthy = true
 
-	err := tp.svc.shutdownTarget(testTargetName)
+	err := tp.svc.shutdownMachine(testMachineName)
 	if err == nil {
 		t.Fatal("expected error from SSH executor, got nil")
 	}
@@ -541,20 +552,20 @@ func TestShutdownTarget_HTTP_Success(t *testing.T) {
 	defer backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.target.Target.SSHHost = "" // clear SSH config
-	tp.target.Target.SSHUser = ""
-	tp.target.Target.SSHKeyPath = ""
-	tp.target.Target.ShutdownCommand = ""
-	tp.target.Target.ShutdownHTTPUrl = backend.URL + "/shutdown"
-	tp.target.IsHealthy = true
+	tp.machine.Machine.SSHHost = "" // clear SSH config
+	tp.machine.Machine.SSHUser = ""
+	tp.machine.Machine.SSHKeyPath = ""
+	tp.machine.Machine.ShutdownCommand = ""
+	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.IsHealthy = true
 
-	err := tp.svc.shutdownTarget(testTargetName)
+	err := tp.svc.shutdownMachine(testMachineName)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	tp.target.mu.RLock()
-	healthy := tp.target.IsHealthy
-	tp.target.mu.RUnlock()
+	tp.machine.mu.RLock()
+	healthy := tp.machine.IsHealthy
+	tp.machine.mu.RUnlock()
 	if healthy {
 		t.Error("expected IsHealthy=false after HTTP shutdown")
 	}
@@ -567,13 +578,13 @@ func TestShutdownTarget_HTTP_NonSuccess(t *testing.T) {
 	defer backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.target.Target.SSHHost = ""
-	tp.target.Target.SSHUser = ""
-	tp.target.Target.SSHKeyPath = ""
-	tp.target.Target.ShutdownCommand = ""
-	tp.target.Target.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.Machine.SSHHost = ""
+	tp.machine.Machine.SSHUser = ""
+	tp.machine.Machine.SSHKeyPath = ""
+	tp.machine.Machine.ShutdownCommand = ""
+	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
 
-	err := tp.svc.shutdownTarget(testTargetName)
+	err := tp.svc.shutdownMachine(testMachineName)
 	if err == nil {
 		t.Fatal("expected error for 500 response, got nil")
 	}
@@ -586,14 +597,14 @@ func TestShutdownTarget_HTTP_CustomOKStatus(t *testing.T) {
 	defer backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.target.Target.SSHHost = ""
-	tp.target.Target.SSHUser = ""
-	tp.target.Target.SSHKeyPath = ""
-	tp.target.Target.ShutdownCommand = ""
-	tp.target.Target.ShutdownHTTPUrl = backend.URL + "/shutdown"
-	tp.target.Target.ShutdownHTTPOKStatus = 202
+	tp.machine.Machine.SSHHost = ""
+	tp.machine.Machine.SSHUser = ""
+	tp.machine.Machine.SSHKeyPath = ""
+	tp.machine.Machine.ShutdownCommand = ""
+	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.Machine.ShutdownHTTPOKStatus = 202
 
-	err := tp.svc.shutdownTarget(testTargetName)
+	err := tp.svc.shutdownMachine(testMachineName)
 	if err != nil {
 		t.Fatalf("expected success for 202 with custom ok_status=202, got: %v", err)
 	}
@@ -606,14 +617,14 @@ func TestShutdownTarget_HTTP_CustomOKStatus_Mismatch(t *testing.T) {
 	defer backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.target.Target.SSHHost = ""
-	tp.target.Target.SSHUser = ""
-	tp.target.Target.SSHKeyPath = ""
-	tp.target.Target.ShutdownCommand = ""
-	tp.target.Target.ShutdownHTTPUrl = backend.URL + "/shutdown"
-	tp.target.Target.ShutdownHTTPOKStatus = 202 // expects 202, gets 200
+	tp.machine.Machine.SSHHost = ""
+	tp.machine.Machine.SSHUser = ""
+	tp.machine.Machine.SSHKeyPath = ""
+	tp.machine.Machine.ShutdownCommand = ""
+	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.Machine.ShutdownHTTPOKStatus = 202 // expects 202, gets 200
 
-	err := tp.svc.shutdownTarget(testTargetName)
+	err := tp.svc.shutdownMachine(testMachineName)
 	if err == nil {
 		t.Fatal("expected error when status doesn't match custom ok_status")
 	}
@@ -621,13 +632,13 @@ func TestShutdownTarget_HTTP_CustomOKStatus_Mismatch(t *testing.T) {
 
 func TestShutdownTarget_NoConfig(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.target.Target.SSHHost = ""
-	tp.target.Target.SSHUser = ""
-	tp.target.Target.SSHKeyPath = ""
-	tp.target.Target.ShutdownCommand = ""
-	tp.target.Target.ShutdownHTTPUrl = ""
+	tp.machine.Machine.SSHHost = ""
+	tp.machine.Machine.SSHUser = ""
+	tp.machine.Machine.SSHKeyPath = ""
+	tp.machine.Machine.ShutdownCommand = ""
+	tp.machine.Machine.ShutdownHTTPUrl = ""
 
-	err := tp.svc.shutdownTarget(testTargetName)
+	err := tp.svc.shutdownMachine(testMachineName)
 	if err == nil {
 		t.Fatal("expected error when no shutdown config, got nil")
 	}
@@ -674,11 +685,15 @@ func TestLoadConfig_Valid(t *testing.T) {
 	if cfg.Timeout != time.Minute {
 		t.Errorf("Timeout = %v, want 1m", cfg.Timeout)
 	}
-	if _, ok := cfg.Targets["server"]; !ok {
-		t.Error("expected target 'server' in map")
+	if _, ok := cfg.Machines["server"]; !ok {
+		t.Error("expected machine 'server' in map")
 	}
-	if cfg.HostnameMap["server.local"] != "server" {
-		t.Errorf("HostnameMap[server.local] = %q, want 'server'", cfg.HostnameMap["server.local"])
+	route, ok := cfg.RoutesByHostname["server.local"]
+	if !ok {
+		t.Fatal("expected a route for hostname server.local")
+	}
+	if route.Machine != cfg.Machines["server"] {
+		t.Error("route server.local should point at machine 'server'")
 	}
 }
 
@@ -751,8 +766,8 @@ func TestLoadConfig_InactivityThreshold(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.InactivityThresholds["server"] != 2*time.Hour {
-		t.Errorf("InactivityThresholds[server] = %v, want 2h", result.InactivityThresholds["server"])
+	if got := result.Machines["server"].Machine.InactivityThreshold; got != 2*time.Hour {
+		t.Errorf("machine server InactivityThreshold = %v, want 2h", got)
 	}
 }
 
@@ -804,7 +819,7 @@ func TestWaitForWake_ContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already cancelled
 
-	err := tp.svc.waitForWake(ctx, tp.target)
+	err := tp.svc.waitForWake(ctx, tp.machine)
 	if err == nil {
 		t.Fatal("expected error from cancelled context, got nil")
 	}
@@ -816,7 +831,7 @@ func TestWaitForWake_Success(t *testing.T) {
 
 	result := make(chan error, 1)
 	go func() {
-		result <- tp.svc.waitForWake(context.Background(), tp.target)
+		result <- tp.svc.waitForWake(context.Background(), tp.machine)
 	}()
 
 	// 2 tickers (wol + healthCheck) + 1 After (timeout) = 3
@@ -845,13 +860,13 @@ func TestWaitForWake_Success(t *testing.T) {
 		t.Error("expected at least one WOL call")
 	}
 
-	tp.target.mu.RLock()
-	defer tp.target.mu.RUnlock()
-	if !tp.target.IsHealthy {
+	tp.machine.mu.RLock()
+	defer tp.machine.mu.RUnlock()
+	if !tp.machine.IsHealthy {
 		t.Error("expected target marked healthy after wake")
 	}
-	if !tp.target.LastCheck.Equal(tp.clock.Now()) {
-		t.Errorf("expected LastCheck primed to %v, got %v", tp.clock.Now(), tp.target.LastCheck)
+	if !tp.machine.LastCheck.Equal(tp.clock.Now()) {
+		t.Errorf("expected LastCheck primed to %v, got %v", tp.clock.Now(), tp.machine.LastCheck)
 	}
 }
 
@@ -861,7 +876,7 @@ func TestWaitForWake_Timeout(t *testing.T) {
 
 	result := make(chan error, 1)
 	go func() {
-		result <- tp.svc.waitForWake(context.Background(), tp.target)
+		result <- tp.svc.waitForWake(context.Background(), tp.machine)
 	}()
 
 	tp.clock.BlockUntil(3)
@@ -886,7 +901,7 @@ func TestWaitForWake_WOLRetransmission(t *testing.T) {
 
 	result := make(chan error, 1)
 	go func() {
-		result <- tp.svc.waitForWake(context.Background(), tp.target)
+		result <- tp.svc.waitForWake(context.Background(), tp.machine)
 	}()
 
 	tp.clock.BlockUntil(3)
@@ -910,12 +925,12 @@ func TestWaitForWake_WOLRetransmission(t *testing.T) {
 
 func TestStartInactivityMonitor_TriggersShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.svc.config.InactivityThresholds[testTargetName] = 30 * time.Minute
+	tp.machine.Machine.InactivityThreshold = 30 * time.Minute
 
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = true
-	tp.target.LastActivity = tp.clock.Now().Add(-1 * time.Hour)
-	tp.target.mu.Unlock()
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastActivity = tp.clock.Now().Add(-1 * time.Hour)
+	tp.machine.mu.Unlock()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -957,11 +972,11 @@ func TestHandleRequest_HealthyTarget(t *testing.T) {
 		fmt.Fprint(w, "hello")
 	}))
 
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = true
-	tp.target.LastCheck = tp.clock.Now()
-	tp.target.LastActivity = tp.clock.Now().Add(-time.Hour)
-	tp.target.mu.Unlock()
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.LastActivity = tp.clock.Now().Add(-time.Hour)
+	tp.machine.mu.Unlock()
 
 	proxy := httptest.NewServer(http.HandlerFunc(tp.svc.handleRequest))
 	defer proxy.Close()
@@ -977,9 +992,9 @@ func TestHandleRequest_HealthyTarget(t *testing.T) {
 		t.Errorf("expected body 'hello', got %q", body)
 	}
 
-	tp.target.mu.RLock()
-	activity := tp.target.LastActivity
-	tp.target.mu.RUnlock()
+	tp.machine.mu.RLock()
+	activity := tp.machine.LastActivity
+	tp.machine.mu.RUnlock()
 	if !activity.Equal(tp.clock.Now()) {
 		t.Errorf("expected LastActivity refreshed to %v, got %v", tp.clock.Now(), activity)
 	}
@@ -1009,9 +1024,9 @@ func TestHandleRequest_UnknownHostname(t *testing.T) {
 
 func TestHandleRequest_WakeTimeout(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = false
-	tp.target.mu.Unlock()
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = false
+	tp.machine.mu.Unlock()
 	tp.health.setResult(false)
 
 	proxy := httptest.NewServer(http.HandlerFunc(tp.svc.handleRequest))
@@ -1041,9 +1056,9 @@ func TestHandleRequest_WakeSuccess(t *testing.T) {
 	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	}))
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = false
-	tp.target.mu.Unlock()
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = false
+	tp.machine.mu.Unlock()
 	tp.health.setResult(false)
 
 	proxy := httptest.NewServer(http.HandlerFunc(tp.svc.handleRequest))
@@ -1076,10 +1091,10 @@ func TestHandleRequest_ExpiredCache_WakesSuccessfully(t *testing.T) {
 	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	}))
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = true
-	tp.target.LastCheck = tp.clock.Now().Add(-15 * time.Second) // stale cache
-	tp.target.mu.Unlock()
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now().Add(-15 * time.Second) // stale cache
+	tp.machine.mu.Unlock()
 	tp.health.setResult(true)
 
 	proxy := httptest.NewServer(http.HandlerFunc(tp.svc.handleRequest))
@@ -1112,11 +1127,11 @@ func TestHandleRequest_BackendError(t *testing.T) {
 	backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.target.Target.Destination = backendURL
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = true
-	tp.target.LastCheck = tp.clock.Now()
-	tp.target.mu.Unlock()
+	tp.route.Destination = backendURL
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
 
 	proxy := httptest.NewServer(http.HandlerFunc(tp.svc.handleRequest))
 	defer proxy.Close()
@@ -1148,11 +1163,11 @@ func TestE2E_ProxyToHealthyTarget(t *testing.T) {
 	defer backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.target.Target.Destination = backend.URL
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = true
-	tp.target.LastCheck = tp.clock.Now()
-	tp.target.mu.Unlock()
+	tp.route.Destination = backend.URL
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
 
 	proxy := httptest.NewServer(http.HandlerFunc(tp.svc.handleRequest))
 	defer proxy.Close()
@@ -1178,9 +1193,9 @@ func TestE2E_ProxyToHealthyTarget(t *testing.T) {
 
 	// LastActivity must be updated after a proxied request.
 	before := tp.clock.Now().Add(-time.Hour)
-	tp.target.mu.RLock()
-	activity := tp.target.LastActivity
-	tp.target.mu.RUnlock()
+	tp.machine.mu.RLock()
+	activity := tp.machine.LastActivity
+	tp.machine.mu.RUnlock()
 	if !activity.After(before) {
 		t.Error("LastActivity was not updated after proxied request")
 	}
@@ -1197,10 +1212,10 @@ func TestE2E_WakeOnDemandAndProxy(t *testing.T) {
 	defer backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.target.Target.Destination = backend.URL
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = false
-	tp.target.mu.Unlock()
+	tp.route.Destination = backend.URL
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = false
+	tp.machine.mu.Unlock()
 	tp.health.setResult(false)
 
 	proxy := httptest.NewServer(http.HandlerFunc(tp.svc.handleRequest))
@@ -1276,12 +1291,12 @@ func TestShutdownTarget_HTTP_Status300(t *testing.T) {
 	}))
 	defer backend.Close()
 	tp := newTestProxy(t, nil)
-	tp.target.Target.SSHHost = ""
-	tp.target.Target.SSHUser = ""
-	tp.target.Target.SSHKeyPath = ""
-	tp.target.Target.ShutdownCommand = ""
-	tp.target.Target.ShutdownHTTPUrl = backend.URL + "/shutdown"
-	if err := tp.svc.shutdownTarget(testTargetName); err == nil {
+	tp.machine.Machine.SSHHost = ""
+	tp.machine.Machine.SSHUser = ""
+	tp.machine.Machine.SSHKeyPath = ""
+	tp.machine.Machine.ShutdownCommand = ""
+	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	if err := tp.svc.shutdownMachine(testMachineName); err == nil {
 		t.Fatal("expected error for status 300 (>= 300 is failure)")
 	}
 }
@@ -1294,13 +1309,13 @@ func TestShutdownTarget_HTTP_CustomMethodHonored(t *testing.T) {
 	}))
 	defer backend.Close()
 	tp := newTestProxy(t, nil)
-	tp.target.Target.SSHHost = ""
-	tp.target.Target.SSHUser = ""
-	tp.target.Target.SSHKeyPath = ""
-	tp.target.Target.ShutdownCommand = ""
-	tp.target.Target.ShutdownHTTPUrl = backend.URL + "/shutdown"
-	tp.target.Target.ShutdownHTTPMethod = "DELETE"
-	if err := tp.svc.shutdownTarget(testTargetName); err != nil {
+	tp.machine.Machine.SSHHost = ""
+	tp.machine.Machine.SSHUser = ""
+	tp.machine.Machine.SSHKeyPath = ""
+	tp.machine.Machine.ShutdownCommand = ""
+	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.Machine.ShutdownHTTPMethod = "DELETE"
+	if err := tp.svc.shutdownMachine(testMachineName); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if gotMethod != "DELETE" {
@@ -1311,12 +1326,12 @@ func TestShutdownTarget_HTTP_CustomMethodHonored(t *testing.T) {
 func TestCheckInactiveTargets_ExactThreshold_NoShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
 	threshold := 30 * time.Minute
-	tp.svc.config.InactivityThresholds[testTargetName] = threshold
-	tp.target.mu.Lock()
-	tp.target.IsHealthy = true
-	tp.target.LastActivity = tp.clock.Now().Add(-threshold) // exactly at threshold, not over
-	tp.target.mu.Unlock()
-	tp.svc.checkInactiveTargets()
+	tp.machine.Machine.InactivityThreshold = threshold
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastActivity = tp.clock.Now().Add(-threshold) // exactly at threshold, not over
+	tp.machine.mu.Unlock()
+	tp.svc.checkInactiveMachines()
 	select {
 	case <-tp.ssh.done:
 		t.Error("shutdown must not trigger when inactiveDuration == threshold (> not >=)")
@@ -1326,9 +1341,9 @@ func TestCheckInactiveTargets_ExactThreshold_NoShutdown(t *testing.T) {
 
 func TestHealthCacheStatus_ExactBoundary_Cached(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.target.IsHealthy = true
-	tp.target.LastCheck = tp.clock.Now().Add(-tp.svc.config.HealthCacheDuration) // age == duration exactly
-	cached, reason := tp.svc.healthCacheStatus(tp.target)
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now().Add(-tp.svc.config.HealthCacheDuration) // age == duration exactly
+	cached, reason := tp.svc.healthCacheStatus(tp.machine)
 	if !cached {
 		t.Errorf("expected cache still valid when age == HealthCacheDuration (> not >=), reason: %s", reason)
 	}
@@ -1360,11 +1375,11 @@ func TestWakeAndWait_ConcurrentRequests_JoinSingleWake(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go func() { tp.svc.wakeAndWait(ctx, tp.target) }()
+	go func() { tp.svc.wakeAndWait(ctx, tp.machine) }()
 	// 1 After (timeout) + 2 tickers (poll, wol) registered once waitForWake is entered.
 	tp.clock.BlockUntil(3)
 
-	go func() { tp.svc.wakeAndWait(ctx, tp.target) }()
+	go func() { tp.svc.wakeAndWait(ctx, tp.machine) }()
 	// The joiner reaches waitForWake too, registering a second set of 3.
 	// Its SendWOL, if any, is recorded before those registrations.
 	tp.clock.BlockUntil(6)
@@ -1381,7 +1396,7 @@ func TestWakeAndWait_FailedPollCycle_KeepsWakeHeld(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go func() { tp.svc.wakeAndWait(ctx, tp.target) }()
+	go func() { tp.svc.wakeAndWait(ctx, tp.machine) }()
 	tp.clock.BlockUntil(3)
 
 	// Drive a full poll cycle that finds the target still down. Both the WOL and
@@ -1393,7 +1408,7 @@ func TestWakeAndWait_FailedPollCycle_KeepsWakeHeld(t *testing.T) {
 	})
 	before := tp.wol.callCount()
 
-	go func() { tp.svc.wakeAndWait(ctx, tp.target) }()
+	go func() { tp.svc.wakeAndWait(ctx, tp.machine) }()
 	tp.clock.BlockUntil(6)
 
 	if got := tp.wol.callCount(); got != before {
@@ -1410,27 +1425,26 @@ func TestBackgroundCheck_StampsLastCheckFromInjectedClock(t *testing.T) {
 	clock := newManualClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
 	hc := NewHTTPHealthChecker(noopLogger{}, clock)
 
-	target := &TargetState{Target: &Target{
-		Name:           testTargetName,
-		Hostname:       testHostname,
-		HealthEndpoint: backend.URL,
+	machine := &MachineState{Machine: &Machine{
+		Name:        testMachineName,
+		HealthCheck: backend.URL,
 	}}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hc.StartBackgroundChecks(ctx, map[string]*TargetState{testTargetName: target}, time.Minute)
+	hc.StartBackgroundChecks(ctx, map[string]*MachineState{testMachineName: machine}, time.Minute)
 	if err := hc.WaitForInitialChecks(ctx); err != nil {
 		t.Fatalf("initial checks did not complete: %v", err)
 	}
 
-	target.mu.RLock()
-	defer target.mu.RUnlock()
-	if !target.IsHealthy {
-		t.Error("expected target healthy after a 200 background check")
+	machine.mu.RLock()
+	defer machine.mu.RUnlock()
+	if !machine.IsHealthy {
+		t.Error("expected machine healthy after a 200 background check")
 	}
-	if !target.LastCheck.Equal(clock.Now()) {
-		t.Errorf("expected LastCheck stamped from the injected clock (%v), got %v", clock.Now(), target.LastCheck)
+	if !machine.LastCheck.Equal(clock.Now()) {
+		t.Errorf("expected LastCheck stamped from the injected clock (%v), got %v", clock.Now(), machine.LastCheck)
 	}
 }
 
@@ -1442,10 +1456,10 @@ func TestLoadConfig_SeedsLastActivityFromInjectedClock(t *testing.T) {
 		t.Fatalf("LoadConfig failed: %v", err)
 	}
 
-	for name, target := range cfg.Targets {
-		if !target.LastActivity.Equal(clock.Now()) {
-			t.Errorf("target %s: expected LastActivity seeded from the injected clock (%v), got %v",
-				name, clock.Now(), target.LastActivity)
+	for name, machine := range cfg.Machines {
+		if !machine.LastActivity.Equal(clock.Now()) {
+			t.Errorf("machine %s: expected LastActivity seeded from the injected clock (%v), got %v",
+				name, clock.Now(), machine.LastActivity)
 		}
 	}
 }
@@ -1467,17 +1481,16 @@ func TestBackgroundCheck_PeriodicTick_DowngradesToUnhealthy(t *testing.T) {
 	clock := newManualClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
 	hc := NewHTTPHealthChecker(noopLogger{}, clock)
 
-	target := &TargetState{Target: &Target{
-		Name:           testTargetName,
-		Hostname:       testHostname,
-		HealthEndpoint: backend.URL,
+	machine := &MachineState{Machine: &Machine{
+		Name:        testMachineName,
+		HealthCheck: backend.URL,
 	}}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	const interval = time.Minute
-	hc.StartBackgroundChecks(ctx, map[string]*TargetState{testTargetName: target}, interval)
+	hc.StartBackgroundChecks(ctx, map[string]*MachineState{testMachineName: machine}, interval)
 	if err := hc.WaitForInitialChecks(ctx); err != nil {
 		t.Fatalf("initial checks did not complete: %v", err)
 	}
@@ -1490,15 +1503,15 @@ func TestBackgroundCheck_PeriodicTick_DowngradesToUnhealthy(t *testing.T) {
 
 	clock.Advance(interval)
 
-	waitFor(t, 5*time.Second, "the periodic check to mark the target unhealthy", func() bool {
-		target.mu.RLock()
-		defer target.mu.RUnlock()
-		return !target.IsHealthy
+	waitFor(t, 5*time.Second, "the periodic check to mark the machine unhealthy", func() bool {
+		machine.mu.RLock()
+		defer machine.mu.RUnlock()
+		return !machine.IsHealthy
 	})
 
-	target.mu.RLock()
-	defer target.mu.RUnlock()
-	if !target.LastCheck.Equal(clock.Now()) {
-		t.Errorf("expected LastCheck advanced to %v, got %v", clock.Now(), target.LastCheck)
+	machine.mu.RLock()
+	defer machine.mu.RUnlock()
+	if !machine.LastCheck.Equal(clock.Now()) {
+		t.Errorf("expected LastCheck advanced to %v, got %v", clock.Now(), machine.LastCheck)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2393,6 +2393,42 @@ func doRequest(t *testing.T, proxyURL string) *http.Response {
 	return resp
 }
 
+func TestHandleRequest_WakeLogNamesTheRoute(t *testing.T) {
+	// The TCP path logs "waking for :2222", but the HTTP path logged a bare
+	// "attempting to wake". With several HTTP routes on one machine, the logs could
+	// not say which hostname pulled the box out of suspend.
+	logger := &recordingLogger{}
+	tp := newTestProxy(t, nil)
+	tp.svc.logger = logger
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = false
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := httptest.NewRequest("GET", "/api/server/ping", nil).WithContext(ctx)
+	r.Host = testHostname
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		tp.svc.handleRequest(w, r)
+		close(done)
+	}()
+
+	// The wake itself never completes here; only the line it logs on the way in
+	// matters. Cancelling the request context unwinds the goroutine afterwards.
+	waitFor(t, 5*time.Second, "the wake log line to name the route", func() bool {
+		return strings.Contains(logger.all(), "waking for "+testHostname)
+	})
+
+	cancel()
+	<-done
+}
+
 func TestHandleRequest_HealthyTarget(t *testing.T) {
 	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)

--- a/main_test.go
+++ b/main_test.go
@@ -2518,6 +2518,31 @@ func doRequest(t *testing.T, proxyURL string) *http.Response {
 	return resp
 }
 
+func TestCheckTCP_CapsTheDialItself(t *testing.T) {
+	// The HTTP checks are capped by http.Client.Timeout, but a tcp:// check is bounded
+	// only by whatever context reaches it — and waitForWake and markReadyIfHealthy
+	// both pass the caller's context straight through with no deadline. Against a host
+	// that drops SYNs rather than refusing them, one dial then blocks for the kernel's
+	// full SYN-retry schedule (~130s on Linux), which is far longer than any configured
+	// timeout and stalls the wake loop that is supposed to be retransmitting WOL.
+	//
+	// This asserts the cap is configured rather than timing a real blackhole: a
+	// reliably-dropping address is not something a test can conjure portably.
+	h := NewEndpointHealthChecker(noopLogger{}, RealClock{})
+
+	if h.dialer.Timeout == 0 {
+		t.Fatal("checkTCP dials with no timeout; a dropped SYN blocks for the kernel retry schedule")
+	}
+	if h.dialer.Timeout != healthCheckTimeout {
+		t.Errorf("dial timeout = %v, want %v to match the HTTP check timeout",
+			h.dialer.Timeout, healthCheckTimeout)
+	}
+	if h.client.Timeout != healthCheckTimeout {
+		t.Errorf("HTTP check timeout = %v, want %v; the two checks should agree",
+			h.client.Timeout, healthCheckTimeout)
+	}
+}
+
 func TestHandleRequest_WakeLogNamesTheRoute(t *testing.T) {
 	// The TCP path logs "waking for :2222", but the HTTP path logged a bare
 	// "attempting to wake". With several HTTP routes on one machine, the logs could

--- a/main_test.go
+++ b/main_test.go
@@ -1787,6 +1787,92 @@ func TestCheckInactiveMachines_HTTPInactivityCountdownRestartsOnRequestEnd(t *te
 	}
 }
 
+func TestServeHTTP_WaitsForInFlightRequestsBeforeReturning(t *testing.T) {
+	// server.Shutdown() closes the listener first, which unblocks server.Serve() with
+	// http.ErrServerClosed while Shutdown is still draining active handlers. If
+	// serveHTTP returns on that signal, Start returns, main logs a clean shutdown and
+	// exits — killing every in-flight response mid-write. The docstring on serveHTTP
+	// promises the opposite; this test pins it.
+	tp := newTestProxy(t, nil)
+
+	release := make(chan struct{})
+	handlerStarted := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		close(handlerStarted)
+		<-release
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("drained"))
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := listener.Addr().String()
+
+	server := &http.Server{Handler: mux}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	served := make(chan error, 1)
+	go func() { served <- tp.svc.serveHTTP(ctx, server, listener) }()
+
+	// Fire the in-flight request against the real listener.
+	responded := make(chan *http.Response, 1)
+	reqErr := make(chan error, 1)
+	go func() {
+		resp, err := http.Get("http://" + addr + "/")
+		if err != nil {
+			reqErr <- err
+			return
+		}
+		responded <- resp
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never received the request")
+	}
+
+	// Ask the server to shut down while the handler is still blocked.
+	cancel()
+
+	// serveHTTP must not return while a handler is still running.
+	select {
+	case err := <-served:
+		t.Fatalf("serveHTTP returned before the in-flight request drained: err=%v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Release the handler; the response must reach the client.
+	close(release)
+
+	select {
+	case resp := <-responded:
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if string(body) != "drained" {
+			t.Errorf("body = %q, want %q — in-flight response was cut off", body, "drained")
+		}
+	case err := <-reqErr:
+		t.Fatalf("in-flight request was dropped by the shutdown: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("request never completed after the handler was released")
+	}
+
+	select {
+	case err := <-served:
+		if err != nil {
+			t.Errorf("serveHTTP returned %v after graceful shutdown, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveHTTP did not return after the handler finished")
+	}
+}
+
 func TestStart_CancelledContextShutsDownWithoutError(t *testing.T) {
 	// main() treats a non-nil return as fatal, so a clean shutdown must return nil.
 	tp := newTestProxy(t, nil)

--- a/main_test.go
+++ b/main_test.go
@@ -1266,6 +1266,62 @@ func newTCPTestProxy(t *testing.T) (*testProxy, *Route, string) {
 	return tp, route, listener.Addr().String()
 }
 
+func TestTCPRoute_LiveMachineButUnreadyRoute_DoesNotDialUpstream(t *testing.T) {
+	// Liveness says the box is up (sshd answers); this route's service has not
+	// started yet. Dialing now would hand the client a closed connection.
+	tp, route, proxyAddr := newTCPTestProxy(t)
+
+	var dialed int32
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstream.Close()
+	go func() {
+		for {
+			conn, err := upstream.Accept()
+			if err != nil {
+				return
+			}
+			atomic.AddInt32(&dialed, 1)
+			conn.Close()
+		}
+	}()
+	route.Destination = upstream.Addr().String()
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	route.mu.Lock()
+	route.IsReady = false
+	route.LastCheck = time.Time{}
+	route.mu.Unlock()
+
+	tp.health.setResult(false)
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Drive the readiness poll past its timeout.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		tp.clock.Advance(tp.svc.config.Timeout + time.Second)
+		time.Sleep(5 * time.Millisecond)
+		if atomic.LoadInt32(&dialed) > 0 {
+			break
+		}
+	}
+
+	if got := atomic.LoadInt32(&dialed); got != 0 {
+		t.Errorf("upstream was dialled %d time(s); an unready route must not be forwarded to", got)
+	}
+}
+
 func TestTCPRoute_ForwardsBytesBothWays(t *testing.T) {
 	tp, _, proxyAddr := newTCPTestProxy(t)
 

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -193,7 +194,7 @@ func (m *mockHealthChecker) Check(_ context.Context, _, _ string) bool {
 	return m.result
 }
 
-func (m *mockHealthChecker) StartBackgroundChecks(_ context.Context, _ map[string]*Machine, _ time.Duration) {
+func (m *mockHealthChecker) StartBackgroundChecks(_ context.Context, _ map[string]*Machine, _ []*Route, _ time.Duration) {
 }
 func (m *mockHealthChecker) WaitForInitialChecks(_ context.Context) error { return nil }
 func (m *mockHealthChecker) CloseIdleConnections()                        {}
@@ -262,10 +263,11 @@ func (m *mockWOLSender) waitForCalls(t *testing.T, n int, timeout time.Duration)
 }
 
 type mockSSHExecutor struct {
-	mu   sync.Mutex
-	done chan struct{}
-	err  error
-	once sync.Once
+	mu       sync.Mutex
+	done     chan struct{}
+	err      error
+	once     sync.Once
+	executed int
 }
 
 func newMockSSHExecutor() *mockSSHExecutor {
@@ -276,7 +278,14 @@ func (m *mockSSHExecutor) ExecuteCommand(_, _, _, _ string) error {
 	m.once.Do(func() { close(m.done) })
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.executed++
 	return m.err
+}
+
+func (m *mockSSHExecutor) calls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.executed
 }
 
 type recordingLogger struct {
@@ -358,10 +367,13 @@ func newTestProxy(t *testing.T, backendHandler http.Handler) *testProxy {
 	}
 
 	route := &Route{
-		Name:        testMachineName,
+		Name:        testHostname,
 		Machine:     machineState,
 		Hostname:    testHostname,
 		Destination: backendURL,
+		HealthCheck: backendURL + "/health",
+		IsReady:     true,
+		LastCheck:   clock.Now(),
 	}
 
 	cfg := &ProxyConfig{
@@ -528,6 +540,40 @@ func TestCheckInactiveTargets_NoThreshold_NoShutdown(t *testing.T) {
 	case <-tp.ssh.done:
 		t.Error("shutdown must not be called when no inactivity threshold is set")
 	default:
+	}
+}
+
+func TestCheckInactiveMachines_TrafficOnOneRouteKeepsTheMachineAlive(t *testing.T) {
+	// Two routes to one box used to mean two targets with the same MAC, each with
+	// its own inactivity clock. The quiet clock would suspend the machine while the
+	// busy one was still serving.
+	tp := newTestProxy(t, nil)
+	tp.machine.Config.InactivityThreshold = 30 * time.Minute
+
+	quiet := &Route{
+		Name:        "quiet.local",
+		Machine:     tp.machine,
+		Hostname:    "quiet.local",
+		Destination: tp.route.Destination,
+	}
+	tp.svc.config.Routes = append(tp.svc.config.Routes, quiet)
+	tp.svc.config.RoutesByHostname["quiet.local"] = quiet
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.mu.Unlock()
+
+	// An hour passes with traffic arriving only on the busy route.
+	for i := 0; i < 4; i++ {
+		tp.clock.Advance(15 * time.Minute)
+		tp.machine.mu.Lock()
+		tp.machine.LastActivity = tp.clock.Now()
+		tp.machine.mu.Unlock()
+		tp.svc.checkInactiveMachines()
+	}
+
+	if got := tp.ssh.calls(); got != 0 {
+		t.Errorf("machine was shut down %d time(s) despite continuous traffic on one of its routes", got)
 	}
 }
 
@@ -1617,6 +1663,67 @@ func TestHandleRequest_HealthyTarget(t *testing.T) {
 	}
 }
 
+func TestHandleRequest_LiveMachineButUnreadyRoute_WaitsInsteadOfForwarding(t *testing.T) {
+	var served int32
+	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&served, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// The box is up, but the service behind this route has not finished starting.
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	tp.route.mu.Lock()
+	tp.route.IsReady = false
+	tp.route.LastCheck = time.Time{}
+	tp.route.mu.Unlock()
+
+	tp.health.setResult(false)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Host = testHostname
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		tp.svc.handleRequest(w, r)
+		close(done)
+	}()
+
+	// Drive the clock forward until the handler returns, so a missing readiness gate
+	// fails the assertions below instead of deadlocking the test.
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				tp.clock.Advance(tp.svc.config.Timeout + time.Second)
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleRequest did not return")
+	}
+
+	if got := atomic.LoadInt32(&served); got != 0 {
+		t.Errorf("backend served %d request(s); an unready route must not be forwarded to", got)
+	}
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+	if tp.wol.callCount() != 0 {
+		t.Error("a live machine should not be sent WOL packets just because a route is unready")
+	}
+}
+
 func TestHandleRequest_UnknownHostname(t *testing.T) {
 	tp := newTestProxy(t, nil)
 
@@ -2050,7 +2157,7 @@ func TestBackgroundCheck_StampsLastCheckFromInjectedClock(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hc.StartBackgroundChecks(ctx, map[string]*Machine{testMachineName: machine}, time.Minute)
+	hc.StartBackgroundChecks(ctx, map[string]*Machine{testMachineName: machine}, nil, time.Minute)
 	if err := hc.WaitForInitialChecks(ctx); err != nil {
 		t.Fatalf("initial checks did not complete: %v", err)
 	}
@@ -2063,6 +2170,73 @@ func TestBackgroundCheck_StampsLastCheckFromInjectedClock(t *testing.T) {
 	if !machine.LastCheck.Equal(clock.Now()) {
 		t.Errorf("expected LastCheck stamped from the injected clock (%v), got %v", clock.Now(), machine.LastCheck)
 	}
+}
+
+func TestBackgroundChecks_RouteReadinessOnlyPolledWhileMachineIsLive(t *testing.T) {
+	var mu sync.Mutex
+	machineUp := false
+	readinessHits := 0
+
+	liveness := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		up := machineUp
+		mu.Unlock()
+		if !up {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer liveness.Close()
+
+	readiness := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		readinessHits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer readiness.Close()
+
+	clock := newManualClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
+	hc := NewEndpointHealthChecker(noopLogger{}, clock)
+
+	machine := &Machine{Name: testMachineName, Config: &MachineConfig{HealthCheck: liveness.URL}}
+	route := &Route{Name: testHostname, Machine: machine, Hostname: testHostname,
+		Destination: readiness.URL, HealthCheck: readiness.URL}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const interval = time.Minute
+	hc.StartBackgroundChecks(ctx, map[string]*Machine{testMachineName: machine}, []*Route{route}, interval)
+	if err := hc.WaitForInitialChecks(ctx); err != nil {
+		t.Fatalf("initial checks did not complete: %v", err)
+	}
+
+	mu.Lock()
+	hitsWhileDown := readinessHits
+	mu.Unlock()
+	if hitsWhileDown != 0 {
+		t.Errorf("route readiness was polled %d time(s) while the machine was down; a sleeping box should generate no per-route traffic", hitsWhileDown)
+	}
+	route.mu.RLock()
+	ready := route.IsReady
+	route.mu.RUnlock()
+	if ready {
+		t.Error("a route on a down machine must not be marked ready")
+	}
+
+	clock.BlockUntil(1)
+	mu.Lock()
+	machineUp = true
+	mu.Unlock()
+	clock.Advance(interval)
+
+	waitFor(t, 5*time.Second, "route readiness to be polled once the machine is live", func() bool {
+		route.mu.RLock()
+		defer route.mu.RUnlock()
+		return route.IsReady
+	})
 }
 
 func TestLoadConfig_SeedsLastActivityFromInjectedClock(t *testing.T) {
@@ -2107,7 +2281,7 @@ func TestBackgroundCheck_PeriodicTick_DowngradesToUnhealthy(t *testing.T) {
 	defer cancel()
 
 	const interval = time.Minute
-	hc.StartBackgroundChecks(ctx, map[string]*Machine{testMachineName: machine}, interval)
+	hc.StartBackgroundChecks(ctx, map[string]*Machine{testMachineName: machine}, nil, interval)
 	if err := hc.WaitForInitialChecks(ctx); err != nil {
 		t.Fatalf("initial checks did not complete: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -1326,6 +1327,61 @@ func TestTCPRoute_LiveMachineButUnreadyRoute_DoesNotDialUpstream(t *testing.T) {
 	}
 }
 
+func TestTCPRoute_ClientHalfCloseStillReceivesTheFullResponse(t *testing.T) {
+	// `ssh host 'cat bigfile' > out` and scp both half-close the client write side
+	// once the request is sent. Tearing the pair down when that direction ends would
+	// truncate the response still streaming back.
+	const payload = 256 * 1024
+
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstream.Close()
+	go func() {
+		for {
+			conn, err := upstream.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				io.Copy(io.Discard, conn) // drain until the client half-closes
+				time.Sleep(50 * time.Millisecond)
+				conn.Write(bytes.Repeat([]byte("y"), payload))
+			}()
+		}
+	}()
+
+	tp, _, proxyAddr := newTCPTestProxy(t, upstream.Addr().String())
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("give me the file\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	got, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("reading the response failed: %v", err)
+	}
+	if len(got) != payload {
+		t.Errorf("received %d bytes, want %d; the response was cut short when the client half-closed", len(got), payload)
+	}
+}
+
 func TestTCPRoute_ForwardsBytesBothWays(t *testing.T) {
 	tp, _, proxyAddr := newTCPTestProxy(t, "")
 
@@ -1698,6 +1754,13 @@ func TestMigrateConfigFile_UnwritableDirectoryLogsTheConfigInstead(t *testing.T)
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { os.Chmod(dir, 0o700) })
+
+	// A root process ignores the directory mode, so there would be nothing to fall
+	// back from.
+	if probe := filepath.Join(dir, ".probe"); os.WriteFile(probe, []byte("x"), 0o600) == nil {
+		os.Remove(probe)
+		t.Skip("this user can write to a read-only directory; the fallback path is unreachable here")
+	}
 
 	logger := &recordingLogger{}
 	MigrateConfigFile(path, logger)

--- a/main_test.go
+++ b/main_test.go
@@ -1353,6 +1353,96 @@ func TestTCPRoute_WakesMachineBeforeForwarding(t *testing.T) {
 	t.Fatal("connection was never forwarded after the machine woke")
 }
 
+func TestCheckInactiveMachines_OpenConnectionBlocksShutdown(t *testing.T) {
+	// An SSH session is idle by nature: hours can pass with no bytes moving. Timing
+	// out on LastActivity alone would suspend the box under a logged-in user.
+	tp, _, proxyAddr := newTCPTestProxy(t)
+	tp.machine.Config.InactivityThreshold = 30 * time.Minute
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("hi\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bufio.NewReader(conn).ReadString('\n'); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 5*time.Second, "the forwarded connection to be counted", func() bool {
+		return tp.machine.openConnections() == 1
+	})
+
+	// Go quiet for well past the threshold while the connection stays open.
+	tp.clock.Advance(2 * time.Hour)
+	tp.svc.checkInactiveMachines()
+
+	if got := tp.ssh.calls(); got != 0 {
+		t.Errorf("machine was shut down %d time(s) with a connection still open", got)
+	}
+
+	conn.Close()
+	waitFor(t, 5*time.Second, "the closed connection to be released", func() bool {
+		return tp.machine.openConnections() == 0
+	})
+
+	tp.clock.Advance(2 * time.Hour)
+	tp.svc.checkInactiveMachines()
+	if got := tp.ssh.calls(); got != 1 {
+		t.Errorf("shutdowns after the connection closed = %d, want 1", got)
+	}
+}
+
+func TestCheckInactiveMachines_InFlightHTTPRequestBlocksShutdown(t *testing.T) {
+	// A slow upload can outlast the inactivity threshold. LastActivity is stamped when
+	// the request starts, so without holding the connection the box would suspend
+	// mid-transfer.
+	release := make(chan struct{})
+	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	tp.machine.Config.InactivityThreshold = 30 * time.Minute
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Host = testHostname
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		tp.svc.handleRequest(w, r)
+		close(done)
+	}()
+
+	waitFor(t, 5*time.Second, "the in-flight request to be counted", func() bool {
+		return tp.machine.openConnections() == 1
+	})
+
+	tp.clock.Advance(2 * time.Hour)
+	tp.svc.checkInactiveMachines()
+	if got := tp.ssh.calls(); got != 0 {
+		t.Errorf("machine was shut down %d time(s) during an in-flight request", got)
+	}
+
+	close(release)
+	<-done
+	waitFor(t, 5*time.Second, "the finished request to be released", func() bool {
+		return tp.machine.openConnections() == 0
+	})
+}
+
 func TestStart_ReportsWhichTCPPortCouldNotBeBound(t *testing.T) {
 	occupied, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -848,6 +848,81 @@ destination = "http://nas.local"
 	mustContain(t, err, "health_chek")
 }
 
+func TestLoadConfig_MachineHealthCheckMustCarryAUsableScheme(t *testing.T) {
+	// Requiring the key to be non-empty is not enough: Check routes tcp:// to a dialer
+	// and everything else to an HTTP client, so a bare "nas.local:22" is parsed as a
+	// URL with scheme "nas.local" and fails every single check. That is the same
+	// permanently-unhealthy machine as an empty value, reached a different way.
+	_, err := LoadConfig(writeTempConfig(t, machineAndRouteHeader+`
+[[machines]]
+name = "nas"
+health_check = "nas.local:22"
+
+[[routes]]
+machine = "nas"
+hostname = "files.home.com"
+destination = "http://nas.local"
+`), RealClock{})
+
+	mustContain(t, err, "nas.local:22", "tcp://")
+}
+
+func TestLoadConfig_RouteHealthCheckMustCarryAUsableScheme(t *testing.T) {
+	// A derived route check is always tcp://host:port, so only an explicit one can be
+	// malformed — and an explicit one is exactly what skips the derivation path.
+	_, err := LoadConfig(writeTempConfig(t, machineAndRouteHeader+`
+[[machines]]
+name = "nas"
+health_check = "tcp://nas.local:22"
+
+[[routes]]
+machine = "nas"
+hostname = "photos.home.com"
+destination = "http://nas.local:2342"
+health_check = "nas.local:2342/ping"
+`), RealClock{})
+
+	mustContain(t, err, "nas.local:2342/ping")
+}
+
+func TestLoadConfig_TCPHealthCheckMustCarryAPort(t *testing.T) {
+	// tcp:// goes straight to SplitHostPort at dial time; catch a missing port here.
+	_, err := LoadConfig(writeTempConfig(t, machineAndRouteHeader+`
+[[machines]]
+name = "nas"
+health_check = "tcp://nas.local"
+
+[[routes]]
+machine = "nas"
+hostname = "files.home.com"
+destination = "http://nas.local"
+`), RealClock{})
+
+	mustContain(t, err, "tcp://nas.local", "host:port")
+}
+
+func TestLoadConfig_AcceptsEveryUsableHealthCheckScheme(t *testing.T) {
+	// The three forms the checker actually understands must keep loading.
+	for _, check := range []string{
+		"tcp://nas.local:22",
+		"http://nas.local/ping",
+		"https://nas.local:8007/api2/json/ping",
+	} {
+		if _, err := LoadConfig(writeTempConfig(t, machineAndRouteHeader+`
+[[machines]]
+name = "nas"
+health_check = "`+check+`"
+
+[[routes]]
+machine = "nas"
+hostname = "files.home.com"
+destination = "http://nas.local"
+`), RealClock{}); err != nil {
+			t.Errorf("health_check %q should load, got %v", check, err)
+		}
+	}
+}
+
 func TestLoadConfig_AcceptsTheShippedExampleConfig(t *testing.T) {
 	// The documented example must survive every rule added here, or the rules are
 	// wrong. Guards the strict unknown-key check against the config we ship.

--- a/main_test.go
+++ b/main_test.go
@@ -1644,6 +1644,54 @@ func TestCheckInactiveMachines_OpenConnectionBlocksShutdown(t *testing.T) {
 	}
 }
 
+func TestCheckInactiveMachines_InactivityCountdownRestartsOnDisconnect(t *testing.T) {
+	// A long-lived TCP session — an ssh login left open past the inactivity threshold
+	// is the motivating case — must not carry a stale LastActivity from when it began.
+	// Without a refresh on release, the very next inactivity tick after logout would
+	// see (now - session start) > threshold and shut the machine down instantly.
+	tp, _, proxyAddr := newTCPTestProxy(t, "")
+	tp.machine.Config.InactivityThreshold = 30 * time.Minute
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write([]byte("hi\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bufio.NewReader(conn).ReadString('\n'); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 5*time.Second, "the forwarded connection to be counted", func() bool {
+		return tp.machine.openConnections() == 1
+	})
+
+	// Hold the session open well past the threshold, then disconnect.
+	tp.clock.Advance(2 * time.Hour)
+	conn.Close()
+	waitFor(t, 5*time.Second, "the closed connection to be released", func() bool {
+		return tp.machine.openConnections() == 0
+	})
+
+	// Immediately after logout the box must stay up: the countdown just restarted.
+	tp.svc.checkInactiveMachines()
+	if got := tp.ssh.calls(); got != 0 {
+		t.Errorf("machine was shut down %d time(s) right after disconnect; countdown must restart on release", got)
+	}
+
+	// Stay quiet past the threshold: now the shutdown should fire.
+	tp.clock.Advance(31 * time.Minute)
+	tp.svc.checkInactiveMachines()
+	if got := tp.ssh.calls(); got != 1 {
+		t.Errorf("shutdowns after threshold elapsed post-disconnect = %d, want 1", got)
+	}
+}
+
 func TestCheckInactiveMachines_InFlightHTTPRequestBlocksShutdown(t *testing.T) {
 	// A slow upload can outlast the inactivity threshold. LastActivity is stamped when
 	// the request starts, so without holding the connection the box would suspend
@@ -1685,6 +1733,58 @@ func TestCheckInactiveMachines_InFlightHTTPRequestBlocksShutdown(t *testing.T) {
 	waitFor(t, 5*time.Second, "the finished request to be released", func() bool {
 		return tp.machine.openConnections() == 0
 	})
+}
+
+func TestCheckInactiveMachines_HTTPInactivityCountdownRestartsOnRequestEnd(t *testing.T) {
+	// Same shape as the TCP disconnect test, on the HTTP path. A slow upload or
+	// long download that outlasts the inactivity threshold must not trigger a
+	// shutdown the moment the response finishes: the countdown restarts at the
+	// end of the request, not at its start.
+	release := make(chan struct{})
+	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	tp.machine.Config.InactivityThreshold = 30 * time.Minute
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Host = testHostname
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		tp.svc.handleRequest(w, r)
+		close(done)
+	}()
+	waitFor(t, 5*time.Second, "the in-flight request to be counted", func() bool {
+		return tp.machine.openConnections() == 1
+	})
+
+	// Hold the request open well past the threshold, then finish it.
+	tp.clock.Advance(2 * time.Hour)
+	close(release)
+	<-done
+	waitFor(t, 5*time.Second, "the finished request to be released", func() bool {
+		return tp.machine.openConnections() == 0
+	})
+
+	// Immediately after the response the box must stay up: the countdown restarted.
+	tp.svc.checkInactiveMachines()
+	if got := tp.ssh.calls(); got != 0 {
+		t.Errorf("machine was shut down %d time(s) right after the request finished; countdown must restart on release", got)
+	}
+
+	// Stay quiet past the threshold: now the shutdown should fire.
+	tp.clock.Advance(31 * time.Minute)
+	tp.svc.checkInactiveMachines()
+	if got := tp.ssh.calls(); got != 1 {
+		t.Errorf("shutdowns after threshold elapsed post-response = %d, want 1", got)
+	}
 }
 
 func TestStart_CancelledContextShutsDownWithoutError(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1234,11 +1234,16 @@ func startEchoBackend(t *testing.T) string {
 }
 
 // newTCPTestProxy wires a TCP route on the shared test machine and starts serving
-// it on an ephemeral port. It returns the proxy and the address to dial.
-func newTCPTestProxy(t *testing.T) (*testProxy, *Route, string) {
+// it on an ephemeral port. Pass destination="" for an echo backend. It returns the
+// proxy and the address to dial. The route must be fully configured before serving
+// starts, so callers that need their own upstream pass it here.
+func newTCPTestProxy(t *testing.T, destination string) (*testProxy, *Route, string) {
 	t.Helper()
 	tp := newTestProxy(t, nil)
-	backendAddr := startEchoBackend(t)
+	backendAddr := destination
+	if backendAddr == "" {
+		backendAddr = startEchoBackend(t)
+	}
 
 	route := &Route{
 		Name:        ":0",
@@ -1269,8 +1274,6 @@ func newTCPTestProxy(t *testing.T) (*testProxy, *Route, string) {
 func TestTCPRoute_LiveMachineButUnreadyRoute_DoesNotDialUpstream(t *testing.T) {
 	// Liveness says the box is up (sshd answers); this route's service has not
 	// started yet. Dialing now would hand the client a closed connection.
-	tp, route, proxyAddr := newTCPTestProxy(t)
-
 	var dialed int32
 	upstream, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -1287,7 +1290,8 @@ func TestTCPRoute_LiveMachineButUnreadyRoute_DoesNotDialUpstream(t *testing.T) {
 			conn.Close()
 		}
 	}()
-	route.Destination = upstream.Addr().String()
+
+	tp, route, proxyAddr := newTCPTestProxy(t, upstream.Addr().String())
 
 	tp.machine.mu.Lock()
 	tp.machine.IsHealthy = true
@@ -1323,7 +1327,7 @@ func TestTCPRoute_LiveMachineButUnreadyRoute_DoesNotDialUpstream(t *testing.T) {
 }
 
 func TestTCPRoute_ForwardsBytesBothWays(t *testing.T) {
-	tp, _, proxyAddr := newTCPTestProxy(t)
+	tp, _, proxyAddr := newTCPTestProxy(t, "")
 
 	tp.machine.mu.Lock()
 	tp.machine.IsHealthy = true
@@ -1362,7 +1366,7 @@ func TestTCPRoute_ForwardsBytesBothWays(t *testing.T) {
 }
 
 func TestTCPRoute_WakesMachineBeforeForwarding(t *testing.T) {
-	tp, _, proxyAddr := newTCPTestProxy(t)
+	tp, _, proxyAddr := newTCPTestProxy(t, "")
 
 	// The box is asleep; the health checker reports it up as soon as it is polled.
 	tp.health.setResult(true)
@@ -1412,7 +1416,7 @@ func TestTCPRoute_WakesMachineBeforeForwarding(t *testing.T) {
 func TestCheckInactiveMachines_OpenConnectionBlocksShutdown(t *testing.T) {
 	// An SSH session is idle by nature: hours can pass with no bytes moving. Timing
 	// out on LastActivity alone would suspend the box under a logged-in user.
-	tp, _, proxyAddr := newTCPTestProxy(t)
+	tp, _, proxyAddr := newTCPTestProxy(t, "")
 	tp.machine.Config.InactivityThreshold = 30 * time.Minute
 
 	tp.machine.mu.Lock()

--- a/main_test.go
+++ b/main_test.go
@@ -1873,6 +1873,131 @@ func TestServeHTTP_WaitsForInFlightRequestsBeforeReturning(t *testing.T) {
 	}
 }
 
+// freePort reserves an ephemeral port and releases it, so a server can bind it by
+// number. Inherently racy, but the window is tiny and it is the only way to know a
+// port before Start binds it.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+func TestStart_WaitsForHTTPDrainWhenTCPRoutesAreConfigured(t *testing.T) {
+	// Start returns the first value sent on errs. A TCP route's serve goroutine
+	// returns nil within microseconds of cancellation — long before serveHTTP has
+	// finished draining — so whenever any TCP route exists that nil is what Start
+	// returns, main logs a clean shutdown and exits mid-response. The drain added to
+	// serveHTTP is correct on its own and completely bypassed here.
+	release := make(chan struct{})
+	handlerStarted := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() { releaseOnce.Do(func() { close(release) }) }
+
+	tp := newTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(handlerStarted)
+		<-release
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("drained"))
+	}))
+	// Registered after newTestProxy so it runs before that helper's backend.Close,
+	// which would otherwise block forever on a still-parked handler when this test
+	// fails early.
+	t.Cleanup(releaseHandler)
+
+	tp.machine.mu.Lock()
+	tp.machine.IsHealthy = true
+	tp.machine.LastCheck = tp.clock.Now()
+	tp.machine.mu.Unlock()
+
+	httpPort := freePort(t)
+	tcpPort := freePort(t)
+
+	tcpRoute := &Route{
+		Name:        fmt.Sprintf(":%d", tcpPort),
+		Machine:     tp.machine,
+		ListenPort:  tcpPort,
+		Destination: "127.0.0.1:1",
+		HealthCheck: "tcp://127.0.0.1:1",
+	}
+	tp.svc.config.Routes = []*Route{tp.route, tcpRoute}
+	tp.svc.config.RoutesByListenPort = map[int]*Route{tcpPort: tcpRoute}
+	tp.svc.config.Port = fmt.Sprintf("127.0.0.1:%d", httpPort)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan error, 1)
+	go func() { started <- tp.svc.Start(ctx) }()
+
+	// Wait for the HTTP listener to come up, then send a request that blocks.
+	waitFor(t, 5*time.Second, "the HTTP listener to accept", func() bool {
+		c, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", httpPort))
+		if err != nil {
+			return false
+		}
+		c.Close()
+		return true
+	})
+
+	responded := make(chan string, 1)
+	reqErr := make(chan error, 1)
+	go func() {
+		req, _ := http.NewRequest("GET", fmt.Sprintf("http://127.0.0.1:%d/", httpPort), nil)
+		req.Host = testHostname
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			reqErr <- err
+			return
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		responded <- string(body)
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend never received the request")
+	}
+
+	cancel()
+
+	// Start must not return while an HTTP handler is still running, however fast the
+	// TCP route's goroutine unwinds.
+	select {
+	case err := <-started:
+		t.Fatalf("Start returned before the in-flight request drained: err=%v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	releaseHandler()
+
+	select {
+	case body := <-responded:
+		if body != "drained" {
+			t.Errorf("body = %q, want %q — the response was cut off by shutdown", body, "drained")
+		}
+	case err := <-reqErr:
+		t.Fatalf("in-flight request was dropped by the shutdown: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("request never completed")
+	}
+
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Errorf("Start returned %v on a cancelled context, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after the handler finished")
+	}
+}
+
 func TestStart_CancelledContextShutsDownWithoutError(t *testing.T) {
 	// main() treats a non-nil return as fatal, so a clean shutdown must return nil.
 	tp := newTestProxy(t, nil)

--- a/main_test.go
+++ b/main_test.go
@@ -192,7 +192,7 @@ func (m *mockHealthChecker) Check(_ context.Context, _, _ string) bool {
 	return m.result
 }
 
-func (m *mockHealthChecker) StartBackgroundChecks(_ context.Context, _ map[string]*MachineState, _ time.Duration) {
+func (m *mockHealthChecker) StartBackgroundChecks(_ context.Context, _ map[string]*Machine, _ time.Duration) {
 }
 func (m *mockHealthChecker) WaitForInitialChecks(_ context.Context) error { return nil }
 func (m *mockHealthChecker) CloseIdleConnections()                        {}
@@ -293,7 +293,7 @@ type testProxy struct {
 	health  *mockHealthChecker
 	wol     *mockWOLSender
 	ssh     *mockSSHExecutor
-	machine *MachineState
+	machine *Machine
 	route   *Route
 	backend *httptest.Server
 }
@@ -322,9 +322,9 @@ func newTestProxy(t *testing.T, backendHandler http.Handler) *testProxy {
 		backendURL = "http://127.0.0.1:19999" // unused port
 	}
 
-	machineState := &MachineState{
-		Machine: &Machine{
-			Name:            testMachineName,
+	machineState := &Machine{
+		Name: testMachineName,
+		Config: &MachineConfig{
 			HealthCheck:     backendURL + "/health",
 			MacAddress:      "AA:BB:CC:DD:EE:FF",
 			BroadcastIP:     "255.255.255.255",
@@ -350,7 +350,7 @@ func newTestProxy(t *testing.T, backendHandler http.Handler) *testProxy {
 		PollInterval:        1 * time.Second,
 		HealthCheckInterval: 30 * time.Second,
 		HealthCacheDuration: 10 * time.Second,
-		Machines:            map[string]*MachineState{testMachineName: machineState},
+		Machines:            map[string]*Machine{testMachineName: machineState},
 		Routes:              []*Route{route},
 		RoutesByHostname:    map[string]*Route{testHostname: route},
 	}
@@ -441,7 +441,7 @@ func TestHealthCacheStatus_NoCheck(t *testing.T) {
 
 func TestCheckInactiveTargets_InactiveHealthy_TriggersShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.InactivityThreshold = 30 * time.Minute
+	tp.machine.Config.InactivityThreshold = 30 * time.Minute
 
 	tp.machine.mu.Lock()
 	tp.machine.IsHealthy = true
@@ -459,7 +459,7 @@ func TestCheckInactiveTargets_InactiveHealthy_TriggersShutdown(t *testing.T) {
 
 func TestCheckInactiveTargets_InactiveUnhealthy_NoShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.InactivityThreshold = 30 * time.Minute
+	tp.machine.Config.InactivityThreshold = 30 * time.Minute
 
 	tp.machine.mu.Lock()
 	tp.machine.IsHealthy = false
@@ -477,7 +477,7 @@ func TestCheckInactiveTargets_InactiveUnhealthy_NoShutdown(t *testing.T) {
 
 func TestCheckInactiveTargets_Active_NoShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.InactivityThreshold = 30 * time.Minute
+	tp.machine.Config.InactivityThreshold = 30 * time.Minute
 
 	tp.machine.mu.Lock()
 	tp.machine.IsHealthy = true
@@ -552,11 +552,11 @@ func TestShutdownTarget_HTTP_Success(t *testing.T) {
 	defer backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.SSHHost = "" // clear SSH config
-	tp.machine.Machine.SSHUser = ""
-	tp.machine.Machine.SSHKeyPath = ""
-	tp.machine.Machine.ShutdownCommand = ""
-	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.Config.SSHHost = "" // clear SSH config
+	tp.machine.Config.SSHUser = ""
+	tp.machine.Config.SSHKeyPath = ""
+	tp.machine.Config.ShutdownCommand = ""
+	tp.machine.Config.ShutdownHTTPUrl = backend.URL + "/shutdown"
 	tp.machine.IsHealthy = true
 
 	err := tp.svc.shutdownMachine(testMachineName)
@@ -578,11 +578,11 @@ func TestShutdownTarget_HTTP_NonSuccess(t *testing.T) {
 	defer backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.SSHHost = ""
-	tp.machine.Machine.SSHUser = ""
-	tp.machine.Machine.SSHKeyPath = ""
-	tp.machine.Machine.ShutdownCommand = ""
-	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.Config.SSHHost = ""
+	tp.machine.Config.SSHUser = ""
+	tp.machine.Config.SSHKeyPath = ""
+	tp.machine.Config.ShutdownCommand = ""
+	tp.machine.Config.ShutdownHTTPUrl = backend.URL + "/shutdown"
 
 	err := tp.svc.shutdownMachine(testMachineName)
 	if err == nil {
@@ -597,12 +597,12 @@ func TestShutdownTarget_HTTP_CustomOKStatus(t *testing.T) {
 	defer backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.SSHHost = ""
-	tp.machine.Machine.SSHUser = ""
-	tp.machine.Machine.SSHKeyPath = ""
-	tp.machine.Machine.ShutdownCommand = ""
-	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
-	tp.machine.Machine.ShutdownHTTPOKStatus = 202
+	tp.machine.Config.SSHHost = ""
+	tp.machine.Config.SSHUser = ""
+	tp.machine.Config.SSHKeyPath = ""
+	tp.machine.Config.ShutdownCommand = ""
+	tp.machine.Config.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.Config.ShutdownHTTPOKStatus = 202
 
 	err := tp.svc.shutdownMachine(testMachineName)
 	if err != nil {
@@ -617,12 +617,12 @@ func TestShutdownTarget_HTTP_CustomOKStatus_Mismatch(t *testing.T) {
 	defer backend.Close()
 
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.SSHHost = ""
-	tp.machine.Machine.SSHUser = ""
-	tp.machine.Machine.SSHKeyPath = ""
-	tp.machine.Machine.ShutdownCommand = ""
-	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
-	tp.machine.Machine.ShutdownHTTPOKStatus = 202 // expects 202, gets 200
+	tp.machine.Config.SSHHost = ""
+	tp.machine.Config.SSHUser = ""
+	tp.machine.Config.SSHKeyPath = ""
+	tp.machine.Config.ShutdownCommand = ""
+	tp.machine.Config.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.Config.ShutdownHTTPOKStatus = 202 // expects 202, gets 200
 
 	err := tp.svc.shutdownMachine(testMachineName)
 	if err == nil {
@@ -632,11 +632,11 @@ func TestShutdownTarget_HTTP_CustomOKStatus_Mismatch(t *testing.T) {
 
 func TestShutdownTarget_NoConfig(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.SSHHost = ""
-	tp.machine.Machine.SSHUser = ""
-	tp.machine.Machine.SSHKeyPath = ""
-	tp.machine.Machine.ShutdownCommand = ""
-	tp.machine.Machine.ShutdownHTTPUrl = ""
+	tp.machine.Config.SSHHost = ""
+	tp.machine.Config.SSHUser = ""
+	tp.machine.Config.SSHKeyPath = ""
+	tp.machine.Config.ShutdownCommand = ""
+	tp.machine.Config.ShutdownHTTPUrl = ""
 
 	err := tp.svc.shutdownMachine(testMachineName)
 	if err == nil {
@@ -694,6 +694,63 @@ func TestLoadConfig_Valid(t *testing.T) {
 	}
 	if route.Machine != cfg.Machines["server"] {
 		t.Error("route server.local should point at machine 'server'")
+	}
+}
+
+const twoTargetConfig = `
+port = "8080"
+timeout = "1m"
+poll_interval = "5s"
+health_check_interval = "30s"
+health_cache_duration = "10s"
+
+[[targets]]
+name = "alpha"
+hostname = "alpha.local"
+destination = "http://192.168.1.10:80"
+health_endpoint = "http://192.168.1.10:80/health"
+mac_address = "AA:BB:CC:DD:EE:FF"
+broadcast_ip = "255.255.255.255"
+wol_port = 9
+
+[[targets]]
+name = "beta"
+hostname = "beta.local"
+destination = "http://192.168.1.11:80"
+health_endpoint = "http://192.168.1.11:80/health"
+mac_address = "11:22:33:44:55:66"
+broadcast_ip = "255.255.255.255"
+wol_port = 9
+`
+
+func TestLoadConfig_EachLegacyTargetBecomesItsOwnMachineAndRoute(t *testing.T) {
+	cfg, err := LoadConfig(writeTempConfig(t, twoTargetConfig), RealClock{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.Machines) != 2 {
+		t.Errorf("Machines = %d, want 2", len(cfg.Machines))
+	}
+	if len(cfg.Routes) != 2 {
+		t.Errorf("Routes = %d, want 2", len(cfg.Routes))
+	}
+
+	for hostname, wantMachine := range map[string]string{"alpha.local": "alpha", "beta.local": "beta"} {
+		route, ok := cfg.RoutesByHostname[hostname]
+		if !ok {
+			t.Fatalf("no route for hostname %s", hostname)
+		}
+		if route.Machine.Name != wantMachine {
+			t.Errorf("route %s points at machine %q, want %q", hostname, route.Machine.Name, wantMachine)
+		}
+		if route.Machine != cfg.Machines[wantMachine] {
+			t.Errorf("route %s does not share the Machine held in cfg.Machines[%q]", hostname, wantMachine)
+		}
+	}
+
+	if cfg.Machines["alpha"].Config.MacAddress == cfg.Machines["beta"].Config.MacAddress {
+		t.Error("machines should keep their own MAC addresses")
 	}
 }
 
@@ -766,7 +823,7 @@ func TestLoadConfig_InactivityThreshold(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := result.Machines["server"].Machine.InactivityThreshold; got != 2*time.Hour {
+	if got := result.Machines["server"].Config.InactivityThreshold; got != 2*time.Hour {
 		t.Errorf("machine server InactivityThreshold = %v, want 2h", got)
 	}
 }
@@ -925,7 +982,7 @@ func TestWaitForWake_WOLRetransmission(t *testing.T) {
 
 func TestStartInactivityMonitor_TriggersShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.InactivityThreshold = 30 * time.Minute
+	tp.machine.Config.InactivityThreshold = 30 * time.Minute
 
 	tp.machine.mu.Lock()
 	tp.machine.IsHealthy = true
@@ -1291,11 +1348,11 @@ func TestShutdownTarget_HTTP_Status300(t *testing.T) {
 	}))
 	defer backend.Close()
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.SSHHost = ""
-	tp.machine.Machine.SSHUser = ""
-	tp.machine.Machine.SSHKeyPath = ""
-	tp.machine.Machine.ShutdownCommand = ""
-	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.Config.SSHHost = ""
+	tp.machine.Config.SSHUser = ""
+	tp.machine.Config.SSHKeyPath = ""
+	tp.machine.Config.ShutdownCommand = ""
+	tp.machine.Config.ShutdownHTTPUrl = backend.URL + "/shutdown"
 	if err := tp.svc.shutdownMachine(testMachineName); err == nil {
 		t.Fatal("expected error for status 300 (>= 300 is failure)")
 	}
@@ -1309,12 +1366,12 @@ func TestShutdownTarget_HTTP_CustomMethodHonored(t *testing.T) {
 	}))
 	defer backend.Close()
 	tp := newTestProxy(t, nil)
-	tp.machine.Machine.SSHHost = ""
-	tp.machine.Machine.SSHUser = ""
-	tp.machine.Machine.SSHKeyPath = ""
-	tp.machine.Machine.ShutdownCommand = ""
-	tp.machine.Machine.ShutdownHTTPUrl = backend.URL + "/shutdown"
-	tp.machine.Machine.ShutdownHTTPMethod = "DELETE"
+	tp.machine.Config.SSHHost = ""
+	tp.machine.Config.SSHUser = ""
+	tp.machine.Config.SSHKeyPath = ""
+	tp.machine.Config.ShutdownCommand = ""
+	tp.machine.Config.ShutdownHTTPUrl = backend.URL + "/shutdown"
+	tp.machine.Config.ShutdownHTTPMethod = "DELETE"
 	if err := tp.svc.shutdownMachine(testMachineName); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1326,7 +1383,7 @@ func TestShutdownTarget_HTTP_CustomMethodHonored(t *testing.T) {
 func TestCheckInactiveTargets_ExactThreshold_NoShutdown(t *testing.T) {
 	tp := newTestProxy(t, nil)
 	threshold := 30 * time.Minute
-	tp.machine.Machine.InactivityThreshold = threshold
+	tp.machine.Config.InactivityThreshold = threshold
 	tp.machine.mu.Lock()
 	tp.machine.IsHealthy = true
 	tp.machine.LastActivity = tp.clock.Now().Add(-threshold) // exactly at threshold, not over
@@ -1425,15 +1482,15 @@ func TestBackgroundCheck_StampsLastCheckFromInjectedClock(t *testing.T) {
 	clock := newManualClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
 	hc := NewHTTPHealthChecker(noopLogger{}, clock)
 
-	machine := &MachineState{Machine: &Machine{
-		Name:        testMachineName,
-		HealthCheck: backend.URL,
-	}}
+	machine := &Machine{
+		Name:   testMachineName,
+		Config: &MachineConfig{HealthCheck: backend.URL},
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hc.StartBackgroundChecks(ctx, map[string]*MachineState{testMachineName: machine}, time.Minute)
+	hc.StartBackgroundChecks(ctx, map[string]*Machine{testMachineName: machine}, time.Minute)
 	if err := hc.WaitForInitialChecks(ctx); err != nil {
 		t.Fatalf("initial checks did not complete: %v", err)
 	}
@@ -1481,16 +1538,16 @@ func TestBackgroundCheck_PeriodicTick_DowngradesToUnhealthy(t *testing.T) {
 	clock := newManualClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
 	hc := NewHTTPHealthChecker(noopLogger{}, clock)
 
-	machine := &MachineState{Machine: &Machine{
-		Name:        testMachineName,
-		HealthCheck: backend.URL,
-	}}
+	machine := &Machine{
+		Name:   testMachineName,
+		Config: &MachineConfig{HealthCheck: backend.URL},
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	const interval = time.Minute
-	hc.StartBackgroundChecks(ctx, map[string]*MachineState{testMachineName: machine}, interval)
+	hc.StartBackgroundChecks(ctx, map[string]*Machine{testMachineName: machine}, interval)
 	if err := hc.WaitForInitialChecks(ctx); err != nil {
 		t.Fatalf("initial checks did not complete: %v", err)
 	}


### PR DESCRIPTION
Splits the old `Target` into a **machine** (woken and shut down as one unit) and a
**route** (one way in), then adds TCP routes on top. Motivation was WOL + shutdown
timer for ssh, but the config model was the real blocker: `Target` conflated the box
with the way in, so two hostnames to one box meant two targets sharing a MAC — two
health checkers and two inactivity clocks that couldn't see each other, where the
quiet one would suspend the machine while the busy one was serving.

```mermaid
graph LR
  A["files.home.com<br/>(HTTP route)"] --> M
  B["photos.home.com<br/>(HTTP route)"] --> M
  C[":2222<br/>(TCP route)"] --> M
  M["machine: nas<br/>one liveness check<br/>one inactivity clock<br/>one shutdown decision"]
```

### Decisions

- **Clean break on config, with auto-migration.** `[[machines]]`/`[[routes]]` is the
  only internal model. Legacy `[[targets]]` is translated at startup and written
  beside the original as `<name>.migrated.toml` — the original is never rewritten,
  since it's usually bind-mounted read-only or in a config repo, and a TOML
  round-trip would drop every comment. Unwritable dir → logged instead.
- **Two health checks, deliberately.** `machines[].health_check` is liveness (drives
  WOL, must not depend on one service); `routes[].health_check` is readiness (gates
  forwarding for that route). Collapsing them would regress the case where the box
  wakes in 8s but the service takes 40s. Route readiness is only polled while its
  machine is live, so a sleeping box generates no per-route traffic.
- **Derived protocol.** A route has `hostname` or `listen_port`, never both, so
  `protocol = "tcp"` would be redundant state that can contradict itself.
- **Connection holds, not just timestamps.** Shutdown needs no traffic *and* no open
  forwarded connection. An ssh session is idle by nature; this also fixes a
  pre-existing hole where a long upload could be suspended mid-transfer.
- **`inactivity_threshold = "0s"` now means "never shut down"** rather than "shut down
  on the first tick".

### Notes for review

- Commit 1 is the model refactor: no behaviour change, the pre-existing 52 tests are
  the net. It couldn't be split into harness/production commits without a
  non-compiling intermediate, so it's atomic instead.
- 52 → 89 tests. Characterization tests (the ones that couldn't go red) were
  mutation-verified; one of them was passing for the wrong reason and got fixed.
- Verified end to end against a hand-written config with an HTTP route and a TCP
  route on one machine, plus the old `config.toml` through the migrator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added raw TCP proxying alongside HTTP routing.
  * Added machine-based configuration with separate routes, TCP ports, readiness checks, and optional TLS.
  * Added HTTP and TCP health checks, automatic machine wake-up, and per-machine inactivity shutdown.
  * Added automatic migration support for legacy target configuration.
* **Bug Fixes**
  * Improved graceful shutdown, connection handling, and half-closed TCP stream support.
  * Prevented inactivity shutdown while connections remain active.
  * Added stronger configuration validation and readiness handling.
* **Documentation**
  * Documented configuration, migration, Docker networking, TCP routing, health checks, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->