### PR TITLE
feat: skip TLS verification for a route's health check on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ There are two `health_check` fields and they answer different questions:
 A route's readiness is only polled while its machine is live, so a machine that is
 asleep most of the time generates no per-route traffic.
 
+**Self-signed HTTPS readiness checks** — set `insecure_health_check = true` on the
+route to make the probe skip TLS verification. The motivating case is Proxmox Backup
+Server, which ships a self-signed cert bound to its container hostname (`pbs`,
+`localhost`) rather than whatever DNS name the proxy reaches it under, so a plain
+`https://…/api2/json/ping` check fails with `x509: certificate is valid for …, not …`.
+The skip is scoped to the health probe only — forwarded traffic on TCP routes is
+spliced byte-for-byte and never touches TLS on the proxy side, so this doesn't
+weaken anything the client already sees.
+
+```toml
+[[routes]]
+machine = "nas"
+listen_port = 8007
+destination = "nas.local:8007"
+health_check = "https://nas.local:8007/api2/json/ping"
+insecure_health_check = true
+```
+
 ### Inactivity and shutdown
 
 Each machine has one inactivity clock, fed by every route that points at it. Traffic

--- a/config.toml
+++ b/config.toml
@@ -60,6 +60,17 @@ machine = "nas"
 listen_port = 2222
 destination = "nas.local:22"
 
+# TCP route to Proxmox Backup Server. PBS ships a self-signed cert bound to its
+# container hostname, so pointing `health_check` at its /api2/json/ping endpoint
+# needs `insecure_health_check = true` — the proxy skips TLS verification for the
+# readiness probe only. Forwarded traffic is raw TCP and unaffected.
+#[[routes]]
+#machine = "nas"
+#listen_port = 8007
+#destination = "nas.local:8007"
+#health_check = "https://nas.local:8007/api2/json/ping"
+#insecure_health_check = true
+
 # A second machine, HTTP only.
 [[machines]]
 name = "media"

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 
 // Interfaces for dependency injection
 type HealthChecker interface {
-	Check(ctx context.Context, endpoint string, source string) bool
+	Check(ctx context.Context, endpoint string, source string, insecure bool) bool
 	StartBackgroundChecks(ctx context.Context, machines map[string]*Machine, routes []*Route, interval time.Duration)
 	WaitForInitialChecks(ctx context.Context) error
 	CloseIdleConnections()
@@ -107,11 +107,12 @@ type MachineEntry struct {
 
 // RouteEntry is a [[routes]] block as written in the config file.
 type RouteEntry struct {
-	Machine     string `toml:"machine"`
-	Hostname    string `toml:"hostname,omitempty"`
-	ListenPort  int    `toml:"listen_port,omitempty"`
-	Destination string `toml:"destination,omitempty"`
-	HealthCheck string `toml:"health_check,omitempty"`
+	Machine             string `toml:"machine"`
+	Hostname            string `toml:"hostname,omitempty"`
+	ListenPort          int    `toml:"listen_port,omitempty"`
+	Destination         string `toml:"destination,omitempty"`
+	HealthCheck         string `toml:"health_check,omitempty"`
+	InsecureHealthCheck bool   `toml:"insecure_health_check,omitempty"`
 }
 
 type Target struct {
@@ -160,6 +161,12 @@ type Route struct {
 	// distinct from the machine's liveness check, which answers whether the box is
 	// up at all. Defaults to dialing Destination.
 	HealthCheck string
+	// InsecureHealthCheck skips TLS verification when HealthCheck is an https:// URL.
+	// The motivating case is Proxmox Backup Server, which ships a self-signed cert
+	// bound to its internal hostname (`pbs`, `localhost`) rather than the external
+	// name the proxy reaches it under. This has no effect on forwarded traffic —
+	// TCP routes splice bytes and never touch TLS.
+	InsecureHealthCheck bool
 
 	IsReady   bool
 	LastCheck time.Time
@@ -236,6 +243,7 @@ func (m *Machine) releaseConnection(now time.Time) {
 // Health checker: dispatches on the endpoint scheme — tcp:// dials, anything else is an HTTP GET
 type EndpointHealthChecker struct {
 	client           *http.Client
+	insecureClient   *http.Client
 	logger           Logger
 	clock            Clock
 	initialCheckDone map[string]bool
@@ -244,13 +252,19 @@ type EndpointHealthChecker struct {
 }
 
 func NewEndpointHealthChecker(logger Logger, clock Clock) *EndpointHealthChecker {
-	transport := &http.Transport{
-		DisableKeepAlives: true,
-	}
 	return &EndpointHealthChecker{
 		client: &http.Client{
-			Timeout:   5 * time.Second,
-			Transport: transport,
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				DisableKeepAlives: true,
+			},
+		},
+		insecureClient: &http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				DisableKeepAlives: true,
+				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+			},
 		},
 		logger:           logger,
 		clock:            clock,
@@ -262,13 +276,16 @@ func (h *EndpointHealthChecker) CloseIdleConnections() {
 	if transport, ok := h.client.Transport.(*http.Transport); ok {
 		transport.CloseIdleConnections()
 	}
+	if transport, ok := h.insecureClient.Transport.(*http.Transport); ok {
+		transport.CloseIdleConnections()
+	}
 }
 
-func (h *EndpointHealthChecker) Check(ctx context.Context, endpoint string, source string) bool {
+func (h *EndpointHealthChecker) Check(ctx context.Context, endpoint string, source string, insecure bool) bool {
 	if address, ok := strings.CutPrefix(endpoint, tcpScheme); ok {
 		return h.checkTCP(ctx, address, source)
 	}
-	return h.checkHTTP(ctx, endpoint, source)
+	return h.checkHTTP(ctx, endpoint, source, insecure)
 }
 
 // checkTCP reports liveness by opening and immediately closing a connection. For
@@ -285,14 +302,18 @@ func (h *EndpointHealthChecker) checkTCP(ctx context.Context, address string, so
 	return true
 }
 
-func (h *EndpointHealthChecker) checkHTTP(ctx context.Context, endpoint string, source string) bool {
+func (h *EndpointHealthChecker) checkHTTP(ctx context.Context, endpoint string, source string, insecure bool) bool {
 	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		h.logger.Info("Health check (%s) failed for %s: %v", source, endpoint, err)
 		return false
 	}
 
-	resp, err := h.client.Do(req)
+	client := h.client
+	if insecure {
+		client = h.insecureClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		h.logger.Info("Health check (%s) failed for %s: %v", source, endpoint, err)
 		return false
@@ -361,7 +382,7 @@ func (h *EndpointHealthChecker) performCheck(ctx context.Context, name string, m
 	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	healthy := h.Check(checkCtx, machine.Config.HealthCheck, "background")
+	healthy := h.Check(checkCtx, machine.Config.HealthCheck, "background", false)
 
 	machine.mu.Lock()
 	previousHealth := machine.IsHealthy
@@ -404,7 +425,7 @@ func (h *EndpointHealthChecker) checkRoutes(ctx context.Context, machine *Machin
 		}
 
 		checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		ready := h.Check(checkCtx, route.HealthCheck, "background")
+		ready := h.Check(checkCtx, route.HealthCheck, "background", route.InsecureHealthCheck)
 		cancel()
 
 		route.mu.Lock()
@@ -916,7 +937,7 @@ func (p *ProxyService) waitForReady(ctx context.Context, route *Route) error {
 }
 
 func (p *ProxyService) markReadyIfHealthy(ctx context.Context, route *Route) bool {
-	if !p.healthChecker.Check(ctx, route.HealthCheck, "readiness") {
+	if !p.healthChecker.Check(ctx, route.HealthCheck, "readiness", route.InsecureHealthCheck) {
 		return false
 	}
 
@@ -1034,7 +1055,7 @@ func (p *ProxyService) waitForWake(ctx context.Context, machine *Machine) error 
 					machine.Name)
 			}
 		case <-healthCheckTicker.C():
-			if p.healthChecker.Check(ctx, machine.Config.HealthCheck, "wake") {
+			if p.healthChecker.Check(ctx, machine.Config.HealthCheck, "wake", false) {
 				machine.mu.Lock()
 				machine.IsHealthy = true
 				machine.LastCheck = p.clock.Now()
@@ -1509,12 +1530,13 @@ func buildMachinesAndRoutes(machineEntries []MachineEntry, routeEntries []RouteE
 		}
 
 		route := &Route{
-			Name:        name,
-			Machine:     machine,
-			Hostname:    entry.Hostname,
-			ListenPort:  entry.ListenPort,
-			Destination: entry.Destination,
-			HealthCheck: healthCheck,
+			Name:                name,
+			Machine:             machine,
+			Hostname:            entry.Hostname,
+			ListenPort:          entry.ListenPort,
+			Destination:         entry.Destination,
+			HealthCheck:         healthCheck,
+			InsecureHealthCheck: entry.InsecureHealthCheck,
 		}
 		routes = append(routes, route)
 		if route.IsTCP() {

--- a/main_test.go
+++ b/main_test.go
@@ -197,7 +197,7 @@ func (m *mockHealthChecker) checks() int {
 	return m.checkCount
 }
 
-func (m *mockHealthChecker) Check(_ context.Context, _, _ string) bool {
+func (m *mockHealthChecker) Check(_ context.Context, _, _ string, _ bool) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.checkCount++
@@ -856,6 +856,38 @@ func TestLoadConfig_MachinesAndRoutes(t *testing.T) {
 	}
 	if route.Machine != machine {
 		t.Error("route should point at the 'nas' machine")
+	}
+}
+
+func TestLoadConfig_InsecureHealthCheckPropagatesToRoute(t *testing.T) {
+	cfg := machinesRoutesConfig + `
+[[routes]]
+machine = "nas"
+listen_port = 8007
+destination = "nas.local:8007"
+health_check = "https://nas.local:8007/api2/json/ping"
+insecure_health_check = true
+`
+	result, err := LoadConfig(writeTempConfig(t, cfg), RealClock{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	route, ok := result.RoutesByListenPort[8007]
+	if !ok {
+		t.Fatalf("expected a route on port 8007, got %v", result.RoutesByListenPort)
+	}
+	if !route.InsecureHealthCheck {
+		t.Error("expected InsecureHealthCheck=true to be carried through from config")
+	}
+
+	// And the default is false for a route that doesn't set it.
+	other, ok := result.RoutesByHostname["files.home.com"]
+	if !ok {
+		t.Fatal("expected the files.home.com route to still be present")
+	}
+	if other.InsecureHealthCheck {
+		t.Error("expected InsecureHealthCheck to default to false when the field is unset")
 	}
 }
 
@@ -2059,7 +2091,7 @@ func TestEndpointHealthChecker_Check_Healthy(t *testing.T) {
 	defer backend.Close()
 
 	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
-	result := hc.Check(context.Background(), backend.URL+"/health", "test")
+	result := hc.Check(context.Background(), backend.URL+"/health", "test", false)
 	if !result {
 		t.Error("expected Check to return true for 200 response")
 	}
@@ -2072,7 +2104,7 @@ func TestEndpointHealthChecker_Check_Unhealthy(t *testing.T) {
 	defer backend.Close()
 
 	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
-	result := hc.Check(context.Background(), backend.URL+"/health", "test")
+	result := hc.Check(context.Background(), backend.URL+"/health", "test", false)
 	if result {
 		t.Error("expected Check to return false for 500 response")
 	}
@@ -2080,7 +2112,7 @@ func TestEndpointHealthChecker_Check_Unhealthy(t *testing.T) {
 
 func TestEndpointHealthChecker_Check_ConnectionRefused(t *testing.T) {
 	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
-	result := hc.Check(context.Background(), "http://127.0.0.1:19998/health", "test")
+	result := hc.Check(context.Background(), "http://127.0.0.1:19998/health", "test", false)
 	if result {
 		t.Error("expected Check to return false for refused connection")
 	}
@@ -2108,20 +2140,39 @@ func TestHealthChecker_Check_TCPScheme(t *testing.T) {
 
 	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
 
-	if !hc.Check(context.Background(), "tcp://"+listener.Addr().String(), "test") {
+	if !hc.Check(context.Background(), "tcp://"+listener.Addr().String(), "test", false) {
 		t.Error("expected a listening socket to be reported healthy")
 	}
 
 	listener.Close()
-	if hc.Check(context.Background(), "tcp://"+listener.Addr().String(), "test") {
+	if hc.Check(context.Background(), "tcp://"+listener.Addr().String(), "test", false) {
 		t.Error("expected a closed socket to be reported unhealthy")
 	}
 }
 
 func TestHealthChecker_Check_TCPSchemeRejectsGarbageAddress(t *testing.T) {
 	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
-	if hc.Check(context.Background(), "tcp://", "test") {
+	if hc.Check(context.Background(), "tcp://", "test", false) {
 		t.Error("expected an empty tcp address to be unhealthy")
+	}
+}
+
+func TestHealthChecker_Check_InsecureSkipsTLSVerification(t *testing.T) {
+	// Self-signed HTTPS is the motivating case: Proxmox Backup Server ships a cert
+	// bound to its container hostname, not the external DNS name the proxy reaches
+	// it under. Without insecure=true, the check must reject; with it, it must pass.
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
+
+	if hc.Check(context.Background(), backend.URL+"/ping", "test", false) {
+		t.Error("expected the check to reject a self-signed cert when insecure=false")
+	}
+	if !hc.Check(context.Background(), backend.URL+"/ping", "test", true) {
+		t.Error("expected the check to accept a self-signed cert when insecure=true")
 	}
 }
 
@@ -2724,7 +2775,7 @@ func TestEndpointHealthChecker_Check_Status300(t *testing.T) {
 	}))
 	defer backend.Close()
 	hc := NewEndpointHealthChecker(noopLogger{}, RealClock{})
-	if hc.Check(context.Background(), backend.URL+"/health", "test") {
+	if hc.Check(context.Background(), backend.URL+"/health", "test", false) {
 		t.Error("expected Check to return false for status 300 (>= 300 is unhealthy)")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `insecure_health_check` (bool, defaults false) to the route config. When true, the readiness probe skips TLS verification, letting `health_check` target a self-signed HTTPS endpoint such as PBS's `/api2/json/ping`.
- Scoped to the readiness probe: forwarded traffic on TCP routes is raw byte splicing and never touches TLS on the proxy side, and machine liveness checks are unchanged.

## Why
Pointing a health check at Proxmox Backup Server via HTTPS otherwise fails with `x509: certificate is valid for pbs, not <external-name>` because PBS ships a self-signed cert bound to its container hostname. The workaround has been to fall back to `tcp://…:22` (sshd), which answers "the box is up" but not "PBS is serving." This gives operators the option to check the real service without dropping cert verification for anything else.

## Test plan
- [x] `go test ./...` green
- [x] New `TestHealthChecker_Check_InsecureSkipsTLSVerification` uses `httptest.NewTLSServer` and asserts: `insecure=false` rejects the self-signed cert, `insecure=true` accepts it. Mutation-verified — removing the client-selection branch fails the test.
- [x] New `TestLoadConfig_InsecureHealthCheckPropagatesToRoute` asserts `insecure_health_check = true` in TOML threads through to `Route.InsecureHealthCheck`, and default remains false. Mutation-verified — dropping the field assignment in `buildMachinesAndRoutes` fails the test.
- [x] All existing tests still pass with the widened `Check` signature (`insecure bool` added).

Stacked on top of `feat/machines-and-routes`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `insecure_health_check` route option for HTTPS readiness checks using self-signed certificates.
  * TLS verification is skipped only for health probes; forwarded TCP traffic remains unchanged.
  * Added configuration examples for Proxmox Backup Server routes.

* **Documentation**
  * Updated the README and sample configuration with setup guidance and security behavior details.

* **Bug Fixes**
  * Improved readiness checks for services using self-signed HTTPS certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->